### PR TITLE
You can now set activation hours from service call

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - **Excluded hours** — Block a time range from ever being activated (e.g., avoid grid fee peak hours)
 - **Multiple instances** — Add one per appliance (water heater, floor heating, pool pump, etc.)
 - **Always on / Always off** — Force all controlled entities ON or OFF via switches, bypassing the schedule
+- **Dynamic hours override** — Adjust scheduled hours at runtime via service calls (ideal for automations based on temperature, weather, etc.)
 - **Emergency mode** — Keeps appliances running if price data is unavailable
 - **No helpers needed** — All configuration is done through the integration's UI
 
@@ -149,6 +150,7 @@ Each instance creates the following sensors:
 | `max_price` | Highest price today |
 | `active_slots` | Total number of active slots in the schedule |
 | `strategy` | Current scheduling strategy (`lowest_price` or `minimum_runtime`) |
+| `schedule_hours_override` | Current hours override value (only present when an override is active) |
 
 ### Override switches
 
@@ -158,6 +160,41 @@ Each instance includes two override switches:
 - **Always off** — Forces all controlled entities OFF regardless of the schedule. The status sensor shows `forced_off`.
 
 The two switches are mutually exclusive — enabling one automatically disables the other. Turn both OFF to resume normal scheduling. Switch states persist across Home Assistant restarts.
+
+### Service calls
+
+Power Saver exposes two services for dynamically overriding the number of scheduled hours at runtime. This is useful when the required runtime depends on external factors like outdoor temperature, solar production, or weather forecasts — call the service from an automation to adjust the schedule on the fly.
+
+| Service | Description |
+|---------|-------------|
+| `power_saver.set_schedule_hours` | Override the number of hours to activate. Works for both strategies (Lowest Price: hours per period; Minimum Runtime: minimum hours on). The schedule is recomputed immediately. The override persists across restarts until cleared. |
+| `power_saver.clear_schedule_hours_override` | Remove a previously set override and revert to the value in the integration options. |
+
+Both services require a `device_id` parameter — the Power Saver device to target. In the UI the device picker only shows Power Saver devices.
+
+**Example automation** — Set heat pump runtime based on outdoor temperature:
+
+```yaml
+automation:
+  - alias: "Adjust heat pump runtime"
+    trigger:
+      - platform: time
+        at: "00:05:00"
+    action:
+      - service: power_saver.set_schedule_hours
+        data:
+          device_id: abc123  # Your Power Saver device ID
+          hours: >-
+            {% set temp = states('sensor.outdoor_temperature') | float(0) %}
+            {% if temp < -15 %}24
+            {% elif temp < -5 %}18
+            {% elif temp < 5 %}12
+            {% elif temp < 15 %}6
+            {% else %}0
+            {% endif %}
+```
+
+When an override is active, the status sensor exposes a `schedule_hours_override` attribute with the current value.
 
 ### Diagnostic sensors
 

--- a/custom_components/power_saver/__init__.py
+++ b/custom_components/power_saver/__init__.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
+import voluptuous as vol
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import device_registry as dr
 
 try:
     from homeassistant.config_entries import OptionsFlowWithReload  # noqa: F401
@@ -12,10 +17,54 @@ try:
 except ImportError:
     _OPTIONS_FLOW_RELOADS = False
 
-from .const import DOMAIN
+from .const import (
+    ATTR_DEVICE_ID,
+    ATTR_HOURS,
+    DOMAIN,
+    SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE,
+    SERVICE_SET_SCHEDULE_HOURS,
+)
 from .coordinator import PowerSaverCoordinator
 
+_LOGGER = logging.getLogger(__name__)
+
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+
+SERVICE_SET_HOURS_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): str,
+        vol.Required(ATTR_HOURS): vol.All(
+            vol.Coerce(float), vol.Range(min=0, max=24)
+        ),
+    }
+)
+
+SERVICE_CLEAR_OVERRIDE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): str,
+    }
+)
+
+
+def _find_coordinator(
+    hass: HomeAssistant, device_id: str
+) -> PowerSaverCoordinator:
+    """Resolve a device_id to its PowerSaverCoordinator.
+
+    Raises ValueError if the device doesn't belong to this integration.
+    """
+    registry = dr.async_get(hass)
+    device = registry.async_get(device_id)
+    if device is None:
+        raise ValueError(f"Device {device_id} not found")
+    # Find the config entry that belongs to Power Saver
+    for entry_id in device.config_entries:
+        coordinator = hass.data.get(DOMAIN, {}).get(entry_id)
+        if coordinator is not None:
+            return coordinator
+    raise ValueError(
+        f"Device {device_id} is not a Power Saver device"
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -35,6 +84,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Register services once (on first entry setup).
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE_HOURS):
+        async def handle_set_schedule_hours(call: ServiceCall) -> None:
+            """Handle the set_schedule_hours service call."""
+            device_id = call.data[ATTR_DEVICE_ID]
+            hours = call.data[ATTR_HOURS]
+            coord = _find_coordinator(hass, device_id)
+            await coord.async_set_hours_override(hours)
+
+        async def handle_clear_override(call: ServiceCall) -> None:
+            """Handle the clear_schedule_hours_override service call."""
+            device_id = call.data[ATTR_DEVICE_ID]
+            coord = _find_coordinator(hass, device_id)
+            await coord.async_clear_hours_override()
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_SCHEDULE_HOURS,
+            handle_set_schedule_hours,
+            schema=SERVICE_SET_HOURS_SCHEMA,
+        )
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE,
+            handle_clear_override,
+            schema=SERVICE_CLEAR_OVERRIDE_SCHEMA,
+        )
+
     return True
 
 
@@ -51,4 +128,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+
+    # Remove services when the last entry is unloaded.
+    if not hass.data.get(DOMAIN):
+        hass.services.async_remove(DOMAIN, SERVICE_SET_SCHEDULE_HOURS)
+        hass.services.async_remove(DOMAIN, SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE)
+
     return unload_ok

--- a/custom_components/power_saver/__init__.py
+++ b/custom_components/power_saver/__init__.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 
 try:
@@ -90,13 +91,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             """Handle the set_schedule_hours service call."""
             device_id = call.data[ATTR_DEVICE_ID]
             hours = call.data[ATTR_HOURS]
-            coord = _find_coordinator(hass, device_id)
+            try:
+                coord = _find_coordinator(hass, device_id)
+            except ValueError as err:
+                raise HomeAssistantError(
+                    f"Device {device_id} not found or not a Power Saver device"
+                ) from err
             await coord.async_set_hours_override(hours)
 
         async def handle_clear_override(call: ServiceCall) -> None:
             """Handle the clear_schedule_hours_override service call."""
             device_id = call.data[ATTR_DEVICE_ID]
-            coord = _find_coordinator(hass, device_id)
+            try:
+                coord = _find_coordinator(hass, device_id)
+            except ValueError as err:
+                raise HomeAssistantError(
+                    f"Device {device_id} not found or not a Power Saver device"
+                ) from err
             await coord.async_clear_hours_override()
 
         hass.services.async_register(
@@ -130,7 +141,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     # Remove services when the last entry is unloaded.
-    if not hass.data.get(DOMAIN):
+    if unload_ok and not hass.data.get(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_SET_SCHEDULE_HOURS)
         hass.services.async_remove(DOMAIN, SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE)
 

--- a/custom_components/power_saver/const.py
+++ b/custom_components/power_saver/const.py
@@ -52,6 +52,14 @@ DEFAULT_PERIOD_FROM = "00:00"
 DEFAULT_PERIOD_TO = "00:00"
 DEFAULT_ROLLING_WINDOW = 28.0
 
+# Service names
+SERVICE_SET_SCHEDULE_HOURS = "set_schedule_hours"
+SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE = "clear_schedule_hours_override"
+
+# Service / attribute keys
+ATTR_HOURS = "hours"
+ATTR_DEVICE_ID = "device_id"
+
 # Update interval in minutes
 UPDATE_INTERVAL_MINUTES = 15
 

--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -546,8 +546,14 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
                     self._last_on_time = None
             hours_override = data.get("hours_override")
             if hours_override is not None:
-                self._hours_override = hours_override
-                _LOGGER.info("Restored hours_override: %s", hours_override)
+                if isinstance(hours_override, (int, float)) and 0 <= hours_override <= 24:
+                    self._hours_override = hours_override
+                    _LOGGER.info("Restored hours_override: %s", hours_override)
+                else:
+                    _LOGGER.warning(
+                        "Ignoring invalid hours_override from storage: %r",
+                        hours_override,
+                    )
         except Exception:
             _LOGGER.exception("Failed to load state from storage")
 

--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -104,6 +104,7 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         self._locked_schedule: list[dict] | None = None
         self._schedule_has_tomorrow: bool = False
         self._options_fingerprint: str | None = None
+        self._hours_override: float | None = None
 
     @property
     def last_on_time(self) -> datetime | None:
@@ -119,6 +120,27 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
     def force_off_active(self) -> bool:
         """Return whether Always off is active."""
         return self._force_off
+
+    @property
+    def hours_override(self) -> float | None:
+        """Return the current hours override, or None if not set."""
+        return self._hours_override
+
+    async def async_set_hours_override(self, hours: float) -> None:
+        """Set a runtime hours override, replacing the config entry value."""
+        self._hours_override = hours
+        self._locked_schedule = None  # Force schedule recomputation
+        _LOGGER.info("Schedule hours override set to %s", hours)
+        await self._async_save_state()
+        await self.async_request_refresh()
+
+    async def async_clear_hours_override(self) -> None:
+        """Clear the runtime hours override, reverting to config entry value."""
+        self._hours_override = None
+        self._locked_schedule = None  # Force schedule recomputation
+        _LOGGER.info("Schedule hours override cleared")
+        await self._async_save_state()
+        await self.async_request_refresh()
 
     async def async_set_force_on(self, active: bool) -> None:
         """Set or clear the Always on state."""
@@ -223,6 +245,7 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         """Compute a deterministic fingerprint of schedule-affecting options."""
         options = self.config_entry.options
         relevant = {k: options.get(k) for k in self._SCHEDULE_OPTIONS_KEYS}
+        relevant["_hours_override"] = self._hours_override
         raw = json.dumps(relevant, sort_keys=True)
         return hashlib.md5(raw.encode()).hexdigest()
 
@@ -318,6 +341,8 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
             min_hours = options.get(CONF_MIN_HOURS_ON, DEFAULT_MIN_HOURS_ON)
         else:
             min_hours = options.get(CONF_HOURS_PER_PERIOD, DEFAULT_HOURS_PER_PERIOD)
+        if self._hours_override is not None:
+            min_hours = self._hours_override
         always_cheap = options.get(CONF_ALWAYS_CHEAP)
         always_expensive = options.get(CONF_ALWAYS_EXPENSIVE)
         price_similarity_pct = options.get(CONF_PRICE_SIMILARITY_PCT)
@@ -519,6 +544,10 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
                     )
                 except (ValueError, TypeError):
                     self._last_on_time = None
+            hours_override = data.get("hours_override")
+            if hours_override is not None:
+                self._hours_override = hours_override
+                _LOGGER.info("Restored hours_override: %s", hours_override)
         except Exception:
             _LOGGER.exception("Failed to load state from storage")
 
@@ -532,6 +561,7 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
                         if self._last_on_time
                         else None
                     ),
+                    "hours_override": self._hours_override,
                 }
             )
         except Exception:

--- a/custom_components/power_saver/sensor.py
+++ b/custom_components/power_saver/sensor.py
@@ -90,13 +90,16 @@ class PowerSaverSensor(CoordinatorEntity[PowerSaverCoordinator], SensorEntity):
         if self.coordinator.data is None:
             return {}
         data: PowerSaverData = self.coordinator.data
-        return {
+        attrs = {
             "current_price": data.current_price,
             "min_price": data.min_price,
             "max_price": data.max_price,
             "active_slots": data.active_slots,
             "strategy": data.strategy,
         }
+        if self.coordinator.hours_override is not None:
+            attrs["schedule_hours_override"] = self.coordinator.hours_override
+        return attrs
 
 
 # --- Diagnostic sensors ---

--- a/custom_components/power_saver/services.yaml
+++ b/custom_components/power_saver/services.yaml
@@ -1,0 +1,41 @@
+set_schedule_hours:
+  name: Set schedule hours
+  description: >-
+    Override the number of hours to activate per period (Lowest Price) or
+    minimum hours on (Minimum Runtime). The schedule is recomputed immediately
+    with the new value. The override persists across restarts until cleared.
+  fields:
+    device_id:
+      name: Device
+      description: The Power Saver device to configure.
+      required: true
+      selector:
+        device:
+          integration: power_saver
+    hours:
+      name: Hours
+      description: >-
+        Number of hours to activate (0–24). Accepts quarter-hour precision
+        (e.g., 4.25 for 4 h 15 min).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 24
+          step: 0.25
+          unit_of_measurement: h
+          mode: box
+
+clear_schedule_hours_override:
+  name: Clear schedule hours override
+  description: >-
+    Remove a previously set hours override and revert to the value configured
+    in the integration options. The schedule is recomputed immediately.
+  fields:
+    device_id:
+      name: Device
+      description: The Power Saver device to configure.
+      required: true
+      selector:
+        device:
+          integration: power_saver

--- a/custom_components/power_saver/strings.json
+++ b/custom_components/power_saver/strings.json
@@ -197,5 +197,31 @@
         "name": "Always off"
       }
     }
+  },
+  "services": {
+    "set_schedule_hours": {
+      "name": "Set schedule hours",
+      "description": "Override the number of hours to activate per period (Lowest Price) or minimum hours on (Minimum Runtime). The schedule is recomputed immediately with the new value. The override persists across restarts until cleared.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        },
+        "hours": {
+          "name": "Hours",
+          "description": "Number of hours to activate (0–24). Accepts quarter-hour precision (e.g., 4.25 for 4 h 15 min)."
+        }
+      }
+    },
+    "clear_schedule_hours_override": {
+      "name": "Clear schedule hours override",
+      "description": "Remove a previously set hours override and revert to the value configured in the integration options. The schedule is recomputed immediately.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        }
+      }
+    }
   }
 }

--- a/custom_components/power_saver/translations/en.json
+++ b/custom_components/power_saver/translations/en.json
@@ -197,5 +197,31 @@
         "name": "Always off"
       }
     }
+  },
+  "services": {
+    "set_schedule_hours": {
+      "name": "Set schedule hours",
+      "description": "Override the number of hours to activate per period (Lowest Price) or minimum hours on (Minimum Runtime). The schedule is recomputed immediately with the new value. The override persists across restarts until cleared.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        },
+        "hours": {
+          "name": "Hours",
+          "description": "Number of hours to activate (0–24). Accepts quarter-hour precision (e.g., 4.25 for 4 h 15 min)."
+        }
+      }
+    },
+    "clear_schedule_hours_override": {
+      "name": "Clear schedule hours override",
+      "description": "Remove a previously set hours override and revert to the value configured in the integration options. The schedule is recomputed immediately.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        }
+      }
+    }
   }
 }

--- a/custom_components/power_saver/translations/sv.json
+++ b/custom_components/power_saver/translations/sv.json
@@ -197,5 +197,31 @@
         "name": "Alltid av"
       }
     }
+  },
+  "services": {
+    "set_schedule_hours": {
+      "name": "Ange schemalagda timmar",
+      "description": "Åsidosätt antalet timmar att aktivera per period (Lägsta pris) eller minsta antal timmar på (Minsta körtid). Schemat beräknas om direkt med det nya värdet. Åsidosättningen sparas mellan omstarter tills den rensas.",
+      "fields": {
+        "device_id": {
+          "name": "Enhet",
+          "description": "Power Saver-enheten att konfigurera."
+        },
+        "hours": {
+          "name": "Timmar",
+          "description": "Antal timmar att aktivera (0–24). Accepterar kvartsprecision (t.ex. 4,25 för 4 h 15 min)."
+        }
+      }
+    },
+    "clear_schedule_hours_override": {
+      "name": "Rensa åsidosättning av schemalagda timmar",
+      "description": "Ta bort en tidigare satt åsidosättning och återgå till värdet i integrationsinställningarna. Schemat beräknas om direkt.",
+      "fields": {
+        "device_id": {
+          "name": "Enhet",
+          "description": "Power Saver-enheten att konfigurera."
+        }
+      }
+    }
   }
 }

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -115,6 +115,7 @@ def test_status_sensor_icon_no_data():
 def test_status_sensor_attributes():
     """Test that main sensor exposes user-facing attributes including strategy."""
     coordinator = MagicMock()
+    coordinator.hours_override = None
     coordinator.data = PowerSaverData(
         current_state="active",
         current_price=0.1,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,281 @@
+"""Tests for the Power Saver service calls (set_schedule_hours, clear_schedule_hours_override)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from helpers import make_config_entry
+
+from custom_components.power_saver.coordinator import PowerSaverCoordinator
+
+
+# --- Coordinator hours override unit tests ---
+
+
+def test_hours_override_default_is_none():
+    """Test the hours override is None by default."""
+    coordinator = MagicMock(spec=PowerSaverCoordinator)
+    coordinator._hours_override = None
+    assert coordinator._hours_override is None
+
+
+async def test_async_set_hours_override():
+    """Test setting hours override stores the value and triggers refresh."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._locked_schedule = [{"time": "2026-01-01T00:00:00", "status": "active"}]
+        coordinator._store = MagicMock()
+        coordinator._store.async_save = AsyncMock()
+        coordinator._last_on_time = None
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.logger = MagicMock()
+
+        await coordinator.async_set_hours_override(18.0)
+
+        assert coordinator._hours_override == 18.0
+        assert coordinator._locked_schedule is None  # Schedule invalidated
+        coordinator.async_request_refresh.assert_awaited_once()
+        coordinator._store.async_save.assert_awaited_once()
+        # Verify saved data includes the override
+        saved_data = coordinator._store.async_save.call_args[0][0]
+        assert saved_data["hours_override"] == 18.0
+
+
+async def test_async_clear_hours_override():
+    """Test clearing hours override removes value and triggers refresh."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = 18.0
+        coordinator._locked_schedule = [{"time": "2026-01-01T00:00:00", "status": "active"}]
+        coordinator._store = MagicMock()
+        coordinator._store.async_save = AsyncMock()
+        coordinator._last_on_time = None
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.logger = MagicMock()
+
+        await coordinator.async_clear_hours_override()
+
+        assert coordinator._hours_override is None
+        assert coordinator._locked_schedule is None  # Schedule invalidated
+        coordinator.async_request_refresh.assert_awaited_once()
+        saved_data = coordinator._store.async_save.call_args[0][0]
+        assert saved_data["hours_override"] is None
+
+
+async def test_hours_override_included_in_fingerprint():
+    """Test that changing hours_override changes the options fingerprint."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {"hours_per_period": 4.0, "strategy": "lowest_price"}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+
+        coordinator._hours_override = None
+        fp_none = coordinator._compute_options_fingerprint()
+
+        coordinator._hours_override = 10.0
+        fp_10 = coordinator._compute_options_fingerprint()
+
+        coordinator._hours_override = 15.0
+        fp_15 = coordinator._compute_options_fingerprint()
+
+        assert fp_none != fp_10
+        assert fp_10 != fp_15
+        assert fp_none != fp_15
+
+
+async def test_hours_override_restored_from_storage():
+    """Test hours_override is restored from persisted storage."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._last_on_time = None
+        coordinator._store = MagicMock()
+        coordinator._store.async_load = AsyncMock(
+            return_value={"last_on_time": None, "hours_override": 12.5}
+        )
+        coordinator.logger = MagicMock()
+
+        await coordinator._async_load_state()
+
+        assert coordinator._hours_override == 12.5
+
+
+async def test_hours_override_not_restored_when_absent():
+    """Test hours_override stays None when not in stored data."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._last_on_time = None
+        coordinator._store = MagicMock()
+        coordinator._store.async_load = AsyncMock(
+            return_value={"last_on_time": None}
+        )
+        coordinator.logger = MagicMock()
+
+        await coordinator._async_load_state()
+
+        assert coordinator._hours_override is None
+
+
+def test_hours_override_property():
+    """Test the hours_override property returns current value."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator._hours_override = None
+        assert coordinator.hours_override is None
+
+        coordinator._hours_override = 6.5
+        assert coordinator.hours_override == 6.5
+
+
+# --- Status sensor override attribute tests ---
+
+
+def test_status_sensor_shows_override_attribute():
+    """Test that the status sensor includes schedule_hours_override when set."""
+    from custom_components.power_saver.coordinator import PowerSaverData
+    from custom_components.power_saver.sensor import PowerSaverSensor
+
+    coordinator = MagicMock()
+    coordinator.data = PowerSaverData(
+        current_state="active",
+        current_price=0.15,
+        min_price=0.05,
+        max_price=0.60,
+        active_slots=40,
+        strategy="lowest_price",
+    )
+    coordinator.hours_override = 18.0
+
+    sensor = PowerSaverSensor(coordinator, make_config_entry())
+    attrs = sensor.extra_state_attributes
+    assert attrs["schedule_hours_override"] == 18.0
+
+
+def test_status_sensor_no_override_attribute_when_none():
+    """Test that schedule_hours_override is absent when no override is set."""
+    from custom_components.power_saver.coordinator import PowerSaverData
+    from custom_components.power_saver.sensor import PowerSaverSensor
+
+    coordinator = MagicMock()
+    coordinator.data = PowerSaverData(
+        current_state="standby",
+        current_price=0.10,
+        min_price=0.05,
+        max_price=0.60,
+        active_slots=20,
+        strategy="lowest_price",
+    )
+    coordinator.hours_override = None
+
+    sensor = PowerSaverSensor(coordinator, make_config_entry())
+    attrs = sensor.extra_state_attributes
+    assert "schedule_hours_override" not in attrs
+
+
+# --- __init__.py service registration tests ---
+
+
+def test_find_coordinator_resolves_device():
+    """Test _find_coordinator resolves device_id to coordinator."""
+    from custom_components.power_saver import _find_coordinator
+
+    hass = MagicMock()
+    coordinator = MagicMock()
+    hass.data = {"power_saver": {"entry_123": coordinator}}
+
+    device = MagicMock()
+    device.config_entries = {"entry_123"}
+
+    with patch(
+        "custom_components.power_saver.dr.async_get"
+    ) as mock_dr:
+        mock_dr.return_value.async_get.return_value = device
+        result = _find_coordinator(hass, "device_abc")
+        assert result is coordinator
+
+
+def test_find_coordinator_raises_for_unknown_device():
+    """Test _find_coordinator raises ValueError for unknown device."""
+    from custom_components.power_saver import _find_coordinator
+
+    hass = MagicMock()
+    hass.data = {"power_saver": {}}
+
+    with patch(
+        "custom_components.power_saver.dr.async_get"
+    ) as mock_dr:
+        mock_dr.return_value.async_get.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            _find_coordinator(hass, "device_unknown")
+
+
+def test_find_coordinator_raises_for_non_power_saver_device():
+    """Test _find_coordinator raises ValueError for device from another integration."""
+    from custom_components.power_saver import _find_coordinator
+
+    hass = MagicMock()
+    hass.data = {"power_saver": {}}
+
+    device = MagicMock()
+    device.config_entries = {"other_entry_id"}
+
+    with patch(
+        "custom_components.power_saver.dr.async_get"
+    ) as mock_dr:
+        mock_dr.return_value.async_get.return_value = device
+        with pytest.raises(ValueError, match="not a Power Saver device"):
+            _find_coordinator(hass, "device_other")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -16,9 +16,12 @@ from custom_components.power_saver.coordinator import PowerSaverCoordinator
 
 def test_hours_override_default_is_none():
     """Test the hours override is None by default."""
-    coordinator = MagicMock(spec=PowerSaverCoordinator)
-    coordinator._hours_override = None
-    assert coordinator._hours_override is None
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator._hours_override = None
+        assert coordinator._hours_override is None
 
 
 async def test_async_set_hours_override():
@@ -83,7 +86,7 @@ async def test_async_clear_hours_override():
         assert saved_data["hours_override"] is None
 
 
-async def test_hours_override_included_in_fingerprint():
+def test_hours_override_included_in_fingerprint():
     """Test that changing hours_override changes the options fingerprint."""
     hass = MagicMock()
     entry = make_config_entry()


### PR DESCRIPTION
Closes https://github.com/jyourstone/power_saver/issues/29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic hours override: set or clear per-device scheduled hours at runtime with immediate recomputation
  * New services to apply and remove schedule overrides; active override exposed as a status attribute

* **Documentation**
  * README updated with service docs and an example automation for temperature-based schedule adjustments

* **Tests**
  * Added tests covering override lifecycle, persistence, sensor attributes, and service resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->