### PR TITLE
Added action call to set excluded time period

### DIFF
--- a/custom_components/power_saver/__init__.py
+++ b/custom_components/power_saver/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE,
     SERVICE_SET_EXCLUDE_TIMES,
     SERVICE_SET_SCHEDULE_HOURS,
+    validate_time_format,
 )
 from .coordinator import PowerSaverCoordinator
 
@@ -38,19 +39,9 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
 def _validate_time(value: str) -> str:
     """Validate a service time value as HH:MM or HH:MM:SS."""
-    if not isinstance(value, str):
-        raise vol.Invalid("Time must be a string")
-    parts = value.split(":")
-    if len(parts) not in (2, 3):
-        raise vol.Invalid("Time must use HH:MM or HH:MM:SS")
-    try:
-        hour = int(parts[0])
-        minute = int(parts[1])
-        second = int(parts[2]) if len(parts) == 3 else 0
-    except ValueError as err:
-        raise vol.Invalid("Time must use numeric HH:MM or HH:MM:SS") from err
-    if not 0 <= hour <= 23 or not 0 <= minute <= 59 or not 0 <= second <= 59:
-        raise vol.Invalid("Time is out of range")
+    is_valid, error = validate_time_format(value)
+    if not is_valid:
+        raise vol.Invalid(error)
     return value
 
 SERVICE_SET_HOURS_SCHEMA = vol.Schema(

--- a/custom_components/power_saver/__init__.py
+++ b/custom_components/power_saver/__init__.py
@@ -20,9 +20,13 @@ except ImportError:
 
 from .const import (
     ATTR_DEVICE_ID,
+    ATTR_EXCLUDE_FROM,
+    ATTR_EXCLUDE_UNTIL,
     ATTR_HOURS,
     DOMAIN,
+    SERVICE_CLEAR_EXCLUDE_TIMES_OVERRIDE,
     SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE,
+    SERVICE_SET_EXCLUDE_TIMES,
     SERVICE_SET_SCHEDULE_HOURS,
 )
 from .coordinator import PowerSaverCoordinator
@@ -30,6 +34,24 @@ from .coordinator import PowerSaverCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
+
+
+def _validate_time(value: str) -> str:
+    """Validate a service time value as HH:MM or HH:MM:SS."""
+    if not isinstance(value, str):
+        raise vol.Invalid("Time must be a string")
+    parts = value.split(":")
+    if len(parts) not in (2, 3):
+        raise vol.Invalid("Time must use HH:MM or HH:MM:SS")
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+    except ValueError as err:
+        raise vol.Invalid("Time must use numeric HH:MM or HH:MM:SS") from err
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59 or not 0 <= second <= 59:
+        raise vol.Invalid("Time is out of range")
+    return value
 
 SERVICE_SET_HOURS_SCHEMA = vol.Schema(
     {
@@ -43,6 +65,14 @@ SERVICE_SET_HOURS_SCHEMA = vol.Schema(
 SERVICE_CLEAR_OVERRIDE_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_DEVICE_ID): str,
+    }
+)
+
+SERVICE_SET_EXCLUDE_TIMES_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): str,
+        vol.Required(ATTR_EXCLUDE_FROM): _validate_time,
+        vol.Required(ATTR_EXCLUDE_UNTIL): _validate_time,
     }
 )
 
@@ -85,41 +115,80 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    async def handle_set_schedule_hours(call: ServiceCall) -> None:
+        """Handle the set_schedule_hours service call."""
+        device_id = call.data[ATTR_DEVICE_ID]
+        hours = call.data[ATTR_HOURS]
+        try:
+            coord = _find_coordinator(hass, device_id)
+        except ValueError as err:
+            raise HomeAssistantError(
+                f"Device {device_id} not found or not a Power Saver device"
+            ) from err
+        await coord.async_set_hours_override(hours)
+
+    async def handle_clear_hours_override(call: ServiceCall) -> None:
+        """Handle the clear_schedule_hours_override service call."""
+        device_id = call.data[ATTR_DEVICE_ID]
+        try:
+            coord = _find_coordinator(hass, device_id)
+        except ValueError as err:
+            raise HomeAssistantError(
+                f"Device {device_id} not found or not a Power Saver device"
+            ) from err
+        await coord.async_clear_hours_override()
+
+    async def handle_set_exclude_times(call: ServiceCall) -> None:
+        """Handle the set_exclude_times service call."""
+        device_id = call.data[ATTR_DEVICE_ID]
+        exclude_from = call.data[ATTR_EXCLUDE_FROM]
+        exclude_until = call.data[ATTR_EXCLUDE_UNTIL]
+        try:
+            coord = _find_coordinator(hass, device_id)
+        except ValueError as err:
+            raise HomeAssistantError(
+                f"Device {device_id} not found or not a Power Saver device"
+            ) from err
+        await coord.async_set_exclude_times_override(exclude_from, exclude_until)
+
+    async def handle_clear_exclude_times_override(call: ServiceCall) -> None:
+        """Handle the clear_exclude_times_override service call."""
+        device_id = call.data[ATTR_DEVICE_ID]
+        try:
+            coord = _find_coordinator(hass, device_id)
+        except ValueError as err:
+            raise HomeAssistantError(
+                f"Device {device_id} not found or not a Power Saver device"
+            ) from err
+        await coord.async_clear_exclude_times_override()
+
     # Register services once (on first entry setup).
     if not hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE_HOURS):
-        async def handle_set_schedule_hours(call: ServiceCall) -> None:
-            """Handle the set_schedule_hours service call."""
-            device_id = call.data[ATTR_DEVICE_ID]
-            hours = call.data[ATTR_HOURS]
-            try:
-                coord = _find_coordinator(hass, device_id)
-            except ValueError as err:
-                raise HomeAssistantError(
-                    f"Device {device_id} not found or not a Power Saver device"
-                ) from err
-            await coord.async_set_hours_override(hours)
-
-        async def handle_clear_override(call: ServiceCall) -> None:
-            """Handle the clear_schedule_hours_override service call."""
-            device_id = call.data[ATTR_DEVICE_ID]
-            try:
-                coord = _find_coordinator(hass, device_id)
-            except ValueError as err:
-                raise HomeAssistantError(
-                    f"Device {device_id} not found or not a Power Saver device"
-                ) from err
-            await coord.async_clear_hours_override()
-
         hass.services.async_register(
             DOMAIN,
             SERVICE_SET_SCHEDULE_HOURS,
             handle_set_schedule_hours,
             schema=SERVICE_SET_HOURS_SCHEMA,
         )
+    if not hass.services.has_service(DOMAIN, SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE):
         hass.services.async_register(
             DOMAIN,
             SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE,
-            handle_clear_override,
+            handle_clear_hours_override,
+            schema=SERVICE_CLEAR_OVERRIDE_SCHEMA,
+        )
+    if not hass.services.has_service(DOMAIN, SERVICE_SET_EXCLUDE_TIMES):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SET_EXCLUDE_TIMES,
+            handle_set_exclude_times,
+            schema=SERVICE_SET_EXCLUDE_TIMES_SCHEMA,
+        )
+    if not hass.services.has_service(DOMAIN, SERVICE_CLEAR_EXCLUDE_TIMES_OVERRIDE):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_CLEAR_EXCLUDE_TIMES_OVERRIDE,
+            handle_clear_exclude_times_override,
             schema=SERVICE_CLEAR_OVERRIDE_SCHEMA,
         )
 
@@ -144,5 +213,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok and not hass.data.get(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_SET_SCHEDULE_HOURS)
         hass.services.async_remove(DOMAIN, SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE)
+        hass.services.async_remove(DOMAIN, SERVICE_SET_EXCLUDE_TIMES)
+        hass.services.async_remove(DOMAIN, SERVICE_CLEAR_EXCLUDE_TIMES_OVERRIDE)
 
     return unload_ok

--- a/custom_components/power_saver/const.py
+++ b/custom_components/power_saver/const.py
@@ -2,6 +2,24 @@
 
 DOMAIN = "power_saver"
 
+
+def validate_time_format(value: object) -> tuple[bool, str | None]:
+    """Validate a time value as HH:MM or HH:MM:SS."""
+    if not isinstance(value, str):
+        return False, "Time must be a string"
+    parts = value.split(":")
+    if len(parts) not in (2, 3):
+        return False, "Time must use HH:MM or HH:MM:SS"
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+    except ValueError:
+        return False, "Time must use numeric HH:MM or HH:MM:SS"
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59 or not 0 <= second <= 59:
+        return False, "Time is out of range"
+    return True, None
+
 # Config entry data keys (immutable after creation)
 CONF_NORDPOOL_SENSOR = "nordpool_sensor"
 CONF_NORDPOOL_TYPE = "nordpool_type"

--- a/custom_components/power_saver/const.py
+++ b/custom_components/power_saver/const.py
@@ -55,10 +55,14 @@ DEFAULT_ROLLING_WINDOW = 28.0
 # Service names
 SERVICE_SET_SCHEDULE_HOURS = "set_schedule_hours"
 SERVICE_CLEAR_SCHEDULE_HOURS_OVERRIDE = "clear_schedule_hours_override"
+SERVICE_SET_EXCLUDE_TIMES = "set_exclude_times"
+SERVICE_CLEAR_EXCLUDE_TIMES_OVERRIDE = "clear_exclude_times_override"
 
 # Service / attribute keys
 ATTR_HOURS = "hours"
 ATTR_DEVICE_ID = "device_id"
+ATTR_EXCLUDE_FROM = "exclude_from"
+ATTR_EXCLUDE_UNTIL = "exclude_until"
 
 # Update interval in minutes
 UPDATE_INTERVAL_MINUTES = 15

--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -79,6 +79,22 @@ class PowerSaverData:
     emergency_mode: bool = False
 
 
+def _is_valid_time(value: object) -> bool:
+    """Return whether value is a supported HH:MM or HH:MM:SS time string."""
+    if not isinstance(value, str):
+        return False
+    parts = value.split(":")
+    if len(parts) not in (2, 3):
+        return False
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+        second = int(parts[2]) if len(parts) == 3 else 0
+    except ValueError:
+        return False
+    return 0 <= hour <= 23 and 0 <= minute <= 59 and 0 <= second <= 59
+
+
 class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
     """Coordinator that manages Power Saver schedule updates."""
 
@@ -107,6 +123,8 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         self._schedule_has_tomorrow: bool = False
         self._options_fingerprint: str | None = None
         self._hours_override: float | None = None
+        self._exclude_from_override: str | None = None
+        self._exclude_until_override: str | None = None
 
     @property
     def last_on_time(self) -> datetime | None:
@@ -128,6 +146,18 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         """Return the current hours override, or None if not set."""
         return self._hours_override
 
+    @property
+    def exclude_times_override(self) -> dict[str, str] | None:
+        """Return the current exclude times override, or None if not set."""
+        exclude_from = getattr(self, "_exclude_from_override", None)
+        exclude_until = getattr(self, "_exclude_until_override", None)
+        if exclude_from is None or exclude_until is None:
+            return None
+        return {
+            "exclude_from": exclude_from,
+            "exclude_until": exclude_until,
+        }
+
     async def async_set_hours_override(self, hours: float) -> None:
         """Set a runtime hours override, replacing the config entry value."""
         self._hours_override = hours
@@ -141,6 +171,30 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         self._hours_override = None
         self._locked_schedule = None  # Force schedule recomputation
         _LOGGER.info("Schedule hours override cleared")
+        await self._async_save_state()
+        await self.async_request_refresh()
+
+    async def async_set_exclude_times_override(
+        self, exclude_from: str, exclude_until: str
+    ) -> None:
+        """Set a runtime exclude times override, replacing config entry values."""
+        self._exclude_from_override = exclude_from
+        self._exclude_until_override = exclude_until
+        self._locked_schedule = None  # Force schedule recomputation
+        _LOGGER.info(
+            "Exclude times override set to %s - %s",
+            exclude_from,
+            exclude_until,
+        )
+        await self._async_save_state()
+        await self.async_request_refresh()
+
+    async def async_clear_exclude_times_override(self) -> None:
+        """Clear the runtime exclude times override, reverting to config values."""
+        self._exclude_from_override = None
+        self._exclude_until_override = None
+        self._locked_schedule = None  # Force schedule recomputation
+        _LOGGER.info("Exclude times override cleared")
         await self._async_save_state()
         await self.async_request_refresh()
 
@@ -248,6 +302,12 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         options = self.config_entry.options
         relevant = {k: options.get(k) for k in self._SCHEDULE_OPTIONS_KEYS}
         relevant["_hours_override"] = self._hours_override
+        relevant["_exclude_from_override"] = getattr(
+            self, "_exclude_from_override", None
+        )
+        relevant["_exclude_until_override"] = getattr(
+            self, "_exclude_until_override", None
+        )
         raw = json.dumps(relevant, sort_keys=True)
         return hashlib.md5(raw.encode()).hexdigest()
 
@@ -336,6 +396,11 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
             self.hass, self._nordpool_entity, self._nordpool_type
         )
 
+        # Load persisted state on first run
+        if not self._state_loaded:
+            await self._async_load_state()
+            self._state_loaded = True
+
         # Read options
         options = self.config_entry.options
         strategy = options.get(CONF_STRATEGY, DEFAULT_STRATEGY)
@@ -352,6 +417,9 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         selection_mode = options.get(CONF_SELECTION_MODE, DEFAULT_SELECTION_MODE)
         exclude_from = options.get(CONF_EXCLUDE_FROM)
         exclude_until = options.get(CONF_EXCLUDE_UNTIL)
+        if self.exclude_times_override is not None:
+            exclude_from = self._exclude_from_override
+            exclude_until = self._exclude_until_override
         # Strategy-specific options
         period_from = options.get(CONF_PERIOD_FROM, DEFAULT_PERIOD_FROM)
         period_to = options.get(CONF_PERIOD_TO, DEFAULT_PERIOD_TO)
@@ -363,11 +431,6 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
                 rolling_window, min_hours,
             )
             max_hours_off = 0
-
-        # Load persisted state on first run
-        if not self._state_loaded:
-            await self._async_load_state()
-            self._state_loaded = True
 
         # Emergency mode: no price data at all
         if not raw_today and not raw_tomorrow:
@@ -560,6 +623,30 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
                         "Ignoring invalid hours_override from storage: %r",
                         hours_override,
                     )
+            exclude_from_override = data.get("exclude_from_override")
+            exclude_until_override = data.get("exclude_until_override")
+            if (
+                exclude_from_override is not None
+                or exclude_until_override is not None
+            ):
+                if (
+                    _is_valid_time(exclude_from_override)
+                    and _is_valid_time(exclude_until_override)
+                ):
+                    self._exclude_from_override = exclude_from_override
+                    self._exclude_until_override = exclude_until_override
+                    _LOGGER.info(
+                        "Restored exclude times override: %s - %s",
+                        exclude_from_override,
+                        exclude_until_override,
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Ignoring invalid exclude times override from storage: "
+                        "%r - %r",
+                        exclude_from_override,
+                        exclude_until_override,
+                    )
         except Exception:
             _LOGGER.exception("Failed to load state from storage")
 
@@ -574,6 +661,12 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
                         else None
                     ),
                     "hours_override": self._hours_override,
+                    "exclude_from_override": getattr(
+                        self, "_exclude_from_override", None
+                    ),
+                    "exclude_until_override": getattr(
+                        self, "_exclude_until_override", None
+                    ),
                 }
             )
         except Exception:

--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -52,6 +52,7 @@ from .const import (
     STRATEGY_LOWEST_PRICE,
     STRATEGY_MINIMUM_RUNTIME,
     UPDATE_INTERVAL_MINUTES,
+    validate_time_format,
 )
 from . import scheduler
 from .nordpool_adapter import async_get_prices
@@ -81,18 +82,8 @@ class PowerSaverData:
 
 def _is_valid_time(value: object) -> bool:
     """Return whether value is a supported HH:MM or HH:MM:SS time string."""
-    if not isinstance(value, str):
-        return False
-    parts = value.split(":")
-    if len(parts) not in (2, 3):
-        return False
-    try:
-        hour = int(parts[0])
-        minute = int(parts[1])
-        second = int(parts[2]) if len(parts) == 3 else 0
-    except ValueError:
-        return False
-    return 0 <= hour <= 23 and 0 <= minute <= 59 and 0 <= second <= 59
+    is_valid, _error = validate_time_format(value)
+    return is_valid
 
 
 class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):

--- a/custom_components/power_saver/sensor.py
+++ b/custom_components/power_saver/sensor.py
@@ -101,6 +101,9 @@ class PowerSaverSensor(CoordinatorEntity[PowerSaverCoordinator], SensorEntity):
         }
         if self.coordinator.hours_override is not None:
             attrs["schedule_hours_override"] = self.coordinator.hours_override
+        exclude_times_override = self.coordinator.exclude_times_override
+        if isinstance(exclude_times_override, dict):
+            attrs["exclude_times_override"] = exclude_times_override
         return attrs
 
 

--- a/custom_components/power_saver/services.yaml
+++ b/custom_components/power_saver/services.yaml
@@ -39,3 +39,47 @@ clear_schedule_hours_override:
       selector:
         device:
           integration: power_saver
+
+set_exclude_times:
+  name: Set exclude times
+  description: >-
+    Override the excluded time range. Slots during this period are never
+    activated. The schedule is recomputed immediately with the new range. The
+    override persists across restarts until cleared.
+  fields:
+    device_id:
+      name: Device
+      description: The Power Saver device to configure.
+      required: true
+      selector:
+        device:
+          integration: power_saver
+    exclude_from:
+      name: Exclude from
+      description: >-
+        Start of the excluded time range. Supports HH:MM and HH:MM:SS.
+      required: true
+      selector:
+        time:
+    exclude_until:
+      name: Exclude until
+      description: >-
+        End of the excluded time range. Supports HH:MM and HH:MM:SS.
+      required: true
+      selector:
+        time:
+
+clear_exclude_times_override:
+  name: Clear exclude times override
+  description: >-
+    Remove a previously set exclude times override and revert to the excluded
+    time range configured in the integration options. The schedule is
+    recomputed immediately.
+  fields:
+    device_id:
+      name: Device
+      description: The Power Saver device to configure.
+      required: true
+      selector:
+        device:
+          integration: power_saver

--- a/custom_components/power_saver/strings.json
+++ b/custom_components/power_saver/strings.json
@@ -228,6 +228,34 @@
           "description": "The Power Saver device to configure."
         }
       }
+    },
+    "set_exclude_times": {
+      "name": "Set exclude times",
+      "description": "Override the excluded time range. Slots during this period are never activated. The schedule is recomputed immediately with the new range. The override persists across restarts until cleared.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        },
+        "exclude_from": {
+          "name": "Exclude from",
+          "description": "Start of the excluded time range. Supports HH:MM and HH:MM:SS."
+        },
+        "exclude_until": {
+          "name": "Exclude until",
+          "description": "End of the excluded time range. Supports HH:MM and HH:MM:SS."
+        }
+      }
+    },
+    "clear_exclude_times_override": {
+      "name": "Clear exclude times override",
+      "description": "Remove a previously set exclude times override and revert to the excluded time range configured in the integration options. The schedule is recomputed immediately.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        }
+      }
     }
   }
 }

--- a/custom_components/power_saver/translations/en.json
+++ b/custom_components/power_saver/translations/en.json
@@ -228,6 +228,34 @@
           "description": "The Power Saver device to configure."
         }
       }
+    },
+    "set_exclude_times": {
+      "name": "Set exclude times",
+      "description": "Override the excluded time range. Slots during this period are never activated. The schedule is recomputed immediately with the new range. The override persists across restarts until cleared.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        },
+        "exclude_from": {
+          "name": "Exclude from",
+          "description": "Start of the excluded time range. Supports HH:MM and HH:MM:SS."
+        },
+        "exclude_until": {
+          "name": "Exclude until",
+          "description": "End of the excluded time range. Supports HH:MM and HH:MM:SS."
+        }
+      }
+    },
+    "clear_exclude_times_override": {
+      "name": "Clear exclude times override",
+      "description": "Remove a previously set exclude times override and revert to the excluded time range configured in the integration options. The schedule is recomputed immediately.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Power Saver device to configure."
+        }
+      }
     }
   }
 }

--- a/custom_components/power_saver/translations/sv.json
+++ b/custom_components/power_saver/translations/sv.json
@@ -228,6 +228,34 @@
           "description": "Power Saver-enheten att konfigurera."
         }
       }
+    },
+    "set_exclude_times": {
+      "name": "Ange exkluderade tider",
+      "description": "Åsidosätt den exkluderade tidsperioden. Tidsluckor under denna period aktiveras aldrig. Schemat beräknas om direkt med den nya perioden. Åsidosättningen sparas mellan omstarter tills den rensas.",
+      "fields": {
+        "device_id": {
+          "name": "Enhet",
+          "description": "Power Saver-enheten att konfigurera."
+        },
+        "exclude_from": {
+          "name": "Exkludera från",
+          "description": "Start på den exkluderade tidsperioden. Stöder HH:MM och HH:MM:SS."
+        },
+        "exclude_until": {
+          "name": "Exkludera till",
+          "description": "Slut på den exkluderade tidsperioden. Stöder HH:MM och HH:MM:SS."
+        }
+      }
+    },
+    "clear_exclude_times_override": {
+      "name": "Rensa åsidosättning av exkluderade tider",
+      "description": "Ta bort en tidigare satt åsidosättning av exkluderade tider och återgå till den exkluderade tidsperioden i integrationsinställningarna. Schemat beräknas om direkt.",
+      "fields": {
+        "device_id": {
+          "name": "Enhet",
+          "description": "Power Saver-enheten att konfigurera."
+        }
+      }
     }
   }
 }

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,10 +1,11 @@
-"""Tests for the Power Saver service calls (set_schedule_hours, clear_schedule_hours_override)."""
+"""Tests for the Power Saver service calls."""
 
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import voluptuous as vol
 
 from helpers import make_config_entry
 
@@ -184,6 +185,234 @@ def test_hours_override_property():
         assert coordinator.hours_override == 6.5
 
 
+# --- Coordinator exclude times override unit tests ---
+
+
+def test_exclude_times_override_default_is_none():
+    """Test the exclude times override is None by default."""
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        assert coordinator.exclude_times_override is None
+
+
+async def test_async_set_exclude_times_override():
+    """Test setting exclude times override stores the values and refreshes."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        coordinator._locked_schedule = [{"time": "2026-01-01T00:00:00", "status": "active"}]
+        coordinator._store = MagicMock()
+        coordinator._store.async_save = AsyncMock()
+        coordinator._last_on_time = None
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.logger = MagicMock()
+
+        await coordinator.async_set_exclude_times_override("22:00", "06:00")
+
+        assert coordinator._exclude_from_override == "22:00"
+        assert coordinator._exclude_until_override == "06:00"
+        assert coordinator._locked_schedule is None
+        coordinator.async_request_refresh.assert_awaited_once()
+        coordinator._store.async_save.assert_awaited_once()
+        saved_data = coordinator._store.async_save.call_args[0][0]
+        assert saved_data["exclude_from_override"] == "22:00"
+        assert saved_data["exclude_until_override"] == "06:00"
+
+
+async def test_async_clear_exclude_times_override():
+    """Test clearing exclude times override removes values and refreshes."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._exclude_from_override = "22:00"
+        coordinator._exclude_until_override = "06:00"
+        coordinator._locked_schedule = [{"time": "2026-01-01T00:00:00", "status": "active"}]
+        coordinator._store = MagicMock()
+        coordinator._store.async_save = AsyncMock()
+        coordinator._last_on_time = None
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.logger = MagicMock()
+
+        await coordinator.async_clear_exclude_times_override()
+
+        assert coordinator._exclude_from_override is None
+        assert coordinator._exclude_until_override is None
+        assert coordinator._locked_schedule is None
+        coordinator.async_request_refresh.assert_awaited_once()
+        saved_data = coordinator._store.async_save.call_args[0][0]
+        assert saved_data["exclude_from_override"] is None
+        assert saved_data["exclude_until_override"] is None
+
+
+def test_exclude_times_override_included_in_fingerprint():
+    """Test that changing exclude times override changes the options fingerprint."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {"exclude_from": "00:00", "exclude_until": "06:00"}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        fp_none = coordinator._compute_options_fingerprint()
+
+        coordinator._exclude_from_override = "22:00"
+        coordinator._exclude_until_override = "06:00"
+        fp_night = coordinator._compute_options_fingerprint()
+
+        coordinator._exclude_from_override = "23:00"
+        coordinator._exclude_until_override = "07:00"
+        fp_late = coordinator._compute_options_fingerprint()
+
+        assert fp_none != fp_night
+        assert fp_night != fp_late
+        assert fp_none != fp_late
+
+
+async def test_exclude_times_override_restored_from_storage():
+    """Test exclude times override is restored from persisted storage."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        coordinator._last_on_time = None
+        coordinator._store = MagicMock()
+        coordinator._store.async_load = AsyncMock(
+            return_value={
+                "last_on_time": None,
+                "exclude_from_override": "22:00",
+                "exclude_until_override": "06:00:00",
+            }
+        )
+        coordinator.logger = MagicMock()
+
+        await coordinator._async_load_state()
+
+        assert coordinator.exclude_times_override == {
+            "exclude_from": "22:00",
+            "exclude_until": "06:00:00",
+        }
+
+
+async def test_exclude_times_override_not_restored_when_absent():
+    """Test exclude times override stays None when not in stored data."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        coordinator._last_on_time = None
+        coordinator._store = MagicMock()
+        coordinator._store.async_load = AsyncMock(
+            return_value={"last_on_time": None}
+        )
+        coordinator.logger = MagicMock()
+
+        await coordinator._async_load_state()
+
+        assert coordinator.exclude_times_override is None
+
+
+async def test_invalid_exclude_times_override_not_restored():
+    """Test invalid persisted exclude times override is ignored."""
+    hass = MagicMock()
+    entry = make_config_entry()
+    entry.options = {}
+    entry.data = {"nordpool_sensor": "sensor.nordpool", "name": "Test", "nordpool_type": "hacs"}
+
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator.hass = hass
+        coordinator.config_entry = entry
+        coordinator._hours_override = None
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        coordinator._last_on_time = None
+        coordinator._store = MagicMock()
+        coordinator._store.async_load = AsyncMock(
+            return_value={
+                "last_on_time": None,
+                "exclude_from_override": "25:00",
+                "exclude_until_override": "06:00",
+            }
+        )
+        coordinator.logger = MagicMock()
+
+        await coordinator._async_load_state()
+
+        assert coordinator.exclude_times_override is None
+
+
+def test_exclude_times_override_property():
+    """Test the exclude_times_override property returns current values."""
+    with patch(
+        "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+    ):
+        coordinator = PowerSaverCoordinator.__new__(PowerSaverCoordinator)
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        assert coordinator.exclude_times_override is None
+
+        coordinator._exclude_from_override = "22:00"
+        coordinator._exclude_until_override = "06:00"
+        assert coordinator.exclude_times_override == {
+            "exclude_from": "22:00",
+            "exclude_until": "06:00",
+        }
+
+
 # --- Status sensor override attribute tests ---
 
 
@@ -202,6 +431,7 @@ def test_status_sensor_shows_override_attribute():
         strategy="lowest_price",
     )
     coordinator.hours_override = 18.0
+    coordinator.exclude_times_override = None
 
     sensor = PowerSaverSensor(coordinator, make_config_entry())
     attrs = sensor.extra_state_attributes
@@ -223,13 +453,94 @@ def test_status_sensor_no_override_attribute_when_none():
         strategy="lowest_price",
     )
     coordinator.hours_override = None
+    coordinator.exclude_times_override = None
 
     sensor = PowerSaverSensor(coordinator, make_config_entry())
     attrs = sensor.extra_state_attributes
     assert "schedule_hours_override" not in attrs
 
 
+def test_status_sensor_shows_exclude_times_override_attribute():
+    """Test that status sensor includes exclude_times_override when set."""
+    from custom_components.power_saver.coordinator import PowerSaverData
+    from custom_components.power_saver.sensor import PowerSaverSensor
+
+    coordinator = MagicMock()
+    coordinator.data = PowerSaverData(
+        current_state="active",
+        current_price=0.15,
+        min_price=0.05,
+        max_price=0.60,
+        active_slots=40,
+        strategy="lowest_price",
+    )
+    coordinator.hours_override = None
+    coordinator.exclude_times_override = {
+        "exclude_from": "22:00",
+        "exclude_until": "06:00",
+    }
+
+    sensor = PowerSaverSensor(coordinator, make_config_entry())
+    attrs = sensor.extra_state_attributes
+    assert attrs["exclude_times_override"] == {
+        "exclude_from": "22:00",
+        "exclude_until": "06:00",
+    }
+
+
+def test_status_sensor_no_exclude_times_override_attribute_when_none():
+    """Test that exclude_times_override is absent when no override is set."""
+    from custom_components.power_saver.coordinator import PowerSaverData
+    from custom_components.power_saver.sensor import PowerSaverSensor
+
+    coordinator = MagicMock()
+    coordinator.data = PowerSaverData(
+        current_state="standby",
+        current_price=0.10,
+        min_price=0.05,
+        max_price=0.60,
+        active_slots=20,
+        strategy="lowest_price",
+    )
+    coordinator.hours_override = None
+    coordinator.exclude_times_override = None
+
+    sensor = PowerSaverSensor(coordinator, make_config_entry())
+    attrs = sensor.extra_state_attributes
+    assert "exclude_times_override" not in attrs
+
+
 # --- __init__.py service registration tests ---
+
+
+def test_set_exclude_times_schema_accepts_supported_time_formats():
+    """Test set_exclude_times service schema accepts HH:MM and HH:MM:SS."""
+    from custom_components.power_saver import SERVICE_SET_EXCLUDE_TIMES_SCHEMA
+
+    data = SERVICE_SET_EXCLUDE_TIMES_SCHEMA(
+        {
+            "device_id": "device_abc",
+            "exclude_from": "22:00",
+            "exclude_until": "06:00:00",
+        }
+    )
+
+    assert data["exclude_from"] == "22:00"
+    assert data["exclude_until"] == "06:00:00"
+
+
+def test_set_exclude_times_schema_rejects_invalid_time():
+    """Test set_exclude_times service schema rejects invalid time strings."""
+    from custom_components.power_saver import SERVICE_SET_EXCLUDE_TIMES_SCHEMA
+
+    with pytest.raises(vol.Invalid):
+        SERVICE_SET_EXCLUDE_TIMES_SCHEMA(
+            {
+                "device_id": "device_abc",
+                "exclude_from": "25:00",
+                "exclude_until": "06:00",
+            }
+        )
 
 
 def test_find_coordinator_resolves_device():


### PR DESCRIPTION
- Implemented services to set and clear excluded time ranges.
- Added validation for time format in exclude times.
- Updated coordinator to manage exclude times overrides.
- Enhanced sensor attributes to include exclude times information.
- Added tests for exclude times service and coordinator behavior.

Closes https://github.com/jyourstone/power_saver/issues/36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added ability to override excluded activation times per device via two new services
* Set custom time windows when Power Saver will never activate (supports HH:MM or HH:MM:SS format)
* Clear exclude-time overrides to revert to default behavior
* Exclude-time overrides now persist across restarts
* Device status attributes now display active exclude-time overrides

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jyourstone/power_saver/pull/39)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->