### PR TITLE
Improved refresh interval tracking

### DIFF
--- a/custom_components/power_saver/__init__.py
+++ b/custom_components/power_saver/__init__.py
@@ -94,6 +94,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = PowerSaverCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
+    coordinator.async_setup_refresh_tracking()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/custom_components/power_saver/__init__.py
+++ b/custom_components/power_saver/__init__.py
@@ -94,6 +94,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = PowerSaverCoordinator(hass, entry)
 
     await coordinator.async_config_entry_first_refresh()
+    # HA versions that call the coordinator setup hook will have already
+    # registered this; keep the explicit call as a compatibility fallback.
     coordinator.async_setup_refresh_tracking()
 
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -65,6 +65,7 @@ _LOGGER = logging.getLogger(__name__)
 
 STORAGE_VERSION = 2
 CLOCK_REFRESH_DELAY_SECONDS = 10
+CLOCK_REFRESH_SUPPRESS_SECONDS = CLOCK_REFRESH_DELAY_SECONDS * 2
 CLOCK_REFRESH_MINUTES = tuple(range(0, 60, UPDATE_INTERVAL_MINUTES))
 
 
@@ -287,7 +288,7 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
             return False
 
         elapsed = dt_util.utcnow() - self._last_nordpool_refresh_request
-        return elapsed <= timedelta(seconds=CLOCK_REFRESH_DELAY_SECONDS)
+        return elapsed <= timedelta(seconds=CLOCK_REFRESH_SUPPRESS_SECONDS)
 
     @callback
     def _request_refresh_from_nordpool(self, source: str) -> None:

--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -9,9 +9,13 @@ import json
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.event import (
+    async_call_later,
+    async_track_state_change_event,
+    async_track_time_change,
+)
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
@@ -60,6 +64,8 @@ from .nordpool_adapter import async_get_prices
 _LOGGER = logging.getLogger(__name__)
 
 STORAGE_VERSION = 2
+CLOCK_REFRESH_DELAY_SECONDS = 10
+CLOCK_REFRESH_MINUTES = tuple(range(0, 60, UPDATE_INTERVAL_MINUTES))
 
 
 @dataclass
@@ -98,15 +104,19 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
             _LOGGER,
             name=f"{DOMAIN}_{entry.entry_id}",
             config_entry=entry,
-            update_interval=timedelta(minutes=UPDATE_INTERVAL_MINUTES),
+            update_interval=None,
         )
         self._nordpool_entity = entry.data[CONF_NORDPOOL_SENSOR]
         self._nordpool_type = entry.data.get(CONF_NORDPOOL_TYPE, NORDPOOL_TYPE_HACS)
         self._store = Store(hass, STORAGE_VERSION, f"power_saver.{entry.entry_id}")
         self._last_on_time: datetime | None = None
         self._state_loaded = False
-        self._unsub_nordpool: callback | None = None
-        self._unsub_native_coordinator: callback | None = None
+        self._refresh_tracking_setup = False
+        self._unsub_nordpool: CALLBACK_TYPE | None = None
+        self._unsub_native_coordinator: CALLBACK_TYPE | None = None
+        self._unsub_clock_refresh: CALLBACK_TYPE | None = None
+        self._unsub_delayed_clock_refresh: CALLBACK_TYPE | None = None
+        self._last_nordpool_refresh_request: datetime | None = None
         self._previous_state: str | None = None
         self._force_on: bool = False
         self._force_off: bool = False
@@ -211,6 +221,16 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
 
     async def _async_setup(self) -> None:
         """Set up the coordinator (called once on first refresh)."""
+        self.async_setup_refresh_tracking()
+
+    @callback
+    def async_setup_refresh_tracking(self) -> None:
+        """Set up event-driven and clock-aligned refresh tracking."""
+        if self._refresh_tracking_setup:
+            return
+
+        self._refresh_tracking_setup = True
+
         # Register Nord Pool state change listener for immediate recalculation
         self._unsub_nordpool = async_track_state_change_event(
             self.hass, [self._nordpool_entity], self._on_nordpool_update
@@ -225,11 +245,67 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         if self._nordpool_type == NORDPOOL_TYPE_NATIVE:
             self._subscribe_native_coordinator()
 
+        # Fallback refresh shortly after each Nord Pool quarter-hour boundary.
+        # The delay gives upstream sensors a small window to publish fresh state.
+        self._unsub_clock_refresh = async_track_time_change(
+            self.hass,
+            self._schedule_clock_refresh,
+            minute=CLOCK_REFRESH_MINUTES,
+            second=0,
+        )
+
+    @callback
+    def _schedule_clock_refresh(self, _now: datetime) -> None:
+        """Schedule a delayed refresh after a quarter-hour boundary."""
+        if self._unsub_delayed_clock_refresh:
+            self._unsub_delayed_clock_refresh()
+            self._unsub_delayed_clock_refresh = None
+
+        if self._recent_nordpool_refresh_request():
+            _LOGGER.debug(
+                "Skipping clock-aligned fallback refresh because Nord Pool "
+                "already requested a refresh near the boundary"
+            )
+            return
+
+        self._unsub_delayed_clock_refresh = async_call_later(
+            self.hass,
+            CLOCK_REFRESH_DELAY_SECONDS,
+            self._on_clock_refresh_delay_elapsed,
+        )
+
+    @callback
+    def _on_clock_refresh_delay_elapsed(self, _now: datetime) -> None:
+        """Refresh after the quarter-hour boundary grace period."""
+        self._unsub_delayed_clock_refresh = None
+        _LOGGER.debug("Clock-aligned refresh boundary reached, requesting refresh")
+        self.hass.async_create_task(self.async_request_refresh())
+
+    def _recent_nordpool_refresh_request(self) -> bool:
+        """Return whether Nord Pool recently requested a refresh."""
+        if self._last_nordpool_refresh_request is None:
+            return False
+
+        elapsed = dt_util.utcnow() - self._last_nordpool_refresh_request
+        return elapsed <= timedelta(seconds=CLOCK_REFRESH_DELAY_SECONDS)
+
+    @callback
+    def _request_refresh_from_nordpool(self, source: str) -> None:
+        """Request refresh from a Nord Pool event and suppress fallback polling."""
+        self._last_nordpool_refresh_request = dt_util.utcnow()
+
+        if self._unsub_delayed_clock_refresh:
+            self._unsub_delayed_clock_refresh()
+            self._unsub_delayed_clock_refresh = None
+            _LOGGER.debug("Cancelled pending clock-aligned fallback refresh")
+
+        _LOGGER.debug("%s updated, requesting refresh", source)
+        self.hass.async_create_task(self.async_request_refresh())
+
     @callback
     def _on_nordpool_update(self, event: Event) -> None:
         """Handle Nord Pool sensor state change."""
-        _LOGGER.debug("Nord Pool sensor updated, requesting refresh")
-        self.hass.async_create_task(self.async_request_refresh())
+        self._request_refresh_from_nordpool("Nord Pool sensor")
 
     def _subscribe_native_coordinator(self) -> None:
         """Subscribe to native Nord Pool coordinator updates.
@@ -268,8 +344,7 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
     @callback
     def _on_native_coordinator_update(self) -> None:
         """Handle native Nord Pool coordinator data update."""
-        _LOGGER.debug("Native Nord Pool coordinator updated, requesting refresh")
-        self.hass.async_create_task(self.async_request_refresh())
+        self._request_refresh_from_nordpool("Native Nord Pool coordinator")
 
     # Options that affect schedule computation (excludes CONF_CONTROLLED_ENTITIES)
     _SCHEDULE_OPTIONS_KEYS = (
@@ -666,10 +741,17 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
     async def async_shutdown(self) -> None:
         """Clean up listeners and persist state."""
         await self._async_save_state()
+        self._refresh_tracking_setup = False
         if self._unsub_nordpool:
             self._unsub_nordpool()
             self._unsub_nordpool = None
         if self._unsub_native_coordinator:
             self._unsub_native_coordinator()
             self._unsub_native_coordinator = None
+        if self._unsub_clock_refresh:
+            self._unsub_clock_refresh()
+            self._unsub_clock_refresh = None
+        if self._unsub_delayed_clock_refresh:
+            self._unsub_delayed_clock_refresh()
+            self._unsub_delayed_clock_refresh = None
         await super().async_shutdown()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import json
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,6 +19,36 @@ sys.path.insert(0, str(_scheduler_path))
 import scheduler  # noqa: E402
 
 build_schedule = scheduler.build_schedule
+NORDPOOL_TYPE_HACS = "hacs"
+NORDPOOL_TYPE_NATIVE = "native"
+EXPECTED_CLOCK_REFRESH_DELAY_SECONDS = 10
+EXPECTED_CLOCK_REFRESH_MINUTES = (0, 15, 30, 45)
+
+
+def _make_coordinator_for_refresh_tracking(nordpool_type=NORDPOOL_TYPE_HACS):
+    """Create a coordinator with enough state for refresh tracking tests."""
+    from custom_components.power_saver.coordinator import PowerSaverCoordinator
+
+    hass = MagicMock()
+    hass.async_create_task = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "test_123"
+    entry.data = {
+        "nordpool_sensor": "sensor.nordpool",
+        "nordpool_type": nordpool_type,
+    }
+    entry.options = {}
+
+    with (
+        patch("custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"),
+        patch("custom_components.power_saver.coordinator.Store"),
+    ):
+        coordinator = PowerSaverCoordinator(hass, entry)
+
+    coordinator.hass = hass
+    coordinator.config_entry = entry
+    coordinator.async_request_refresh = MagicMock()
+    return coordinator
 
 
 @pytest.fixture
@@ -49,6 +79,217 @@ def tomorrow_prices() -> list[dict]:
         0.50, 0.55, 0.45, 0.30, 0.18, 0.10,  # 18-23
     ]
     return [slot for h, p in enumerate(prices) for slot in make_nordpool_hour(h, p, day_offset=1)]
+
+
+class TestRefreshTracking:
+    """Tests for event-driven and clock-aligned coordinator refresh tracking."""
+
+    def test_data_update_coordinator_polling_is_disabled(self):
+        """Coordinator should not use drift-prone fixed interval polling."""
+        from custom_components.power_saver.coordinator import PowerSaverCoordinator
+
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "test_123"
+        entry.data = {
+            "nordpool_sensor": "sensor.nordpool",
+            "nordpool_type": NORDPOOL_TYPE_HACS,
+        }
+
+        with (
+            patch(
+                "custom_components.power_saver.coordinator.DataUpdateCoordinator.__init__"
+            ) as mock_init,
+            patch("custom_components.power_saver.coordinator.Store"),
+        ):
+            PowerSaverCoordinator(hass, entry)
+
+        assert mock_init.call_args.kwargs["update_interval"] is None
+
+    def test_setup_refresh_tracking_registers_hacs_listeners_once(self):
+        """HACS setups should register Nord Pool and fallback listeners once."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        unsub_nordpool = MagicMock()
+        unsub_clock = MagicMock()
+
+        with (
+            patch(
+                "custom_components.power_saver.coordinator.async_track_state_change_event",
+                return_value=unsub_nordpool,
+            ) as mock_track_state,
+            patch(
+                "custom_components.power_saver.coordinator.async_track_time_change",
+                return_value=unsub_clock,
+            ) as mock_track_time,
+            patch.object(coordinator, "_subscribe_native_coordinator") as mock_native,
+        ):
+            coordinator.async_setup_refresh_tracking()
+            coordinator.async_setup_refresh_tracking()
+
+        mock_track_state.assert_called_once_with(
+            coordinator.hass,
+            ["sensor.nordpool"],
+            coordinator._on_nordpool_update,
+        )
+        mock_track_time.assert_called_once_with(
+            coordinator.hass,
+            coordinator._schedule_clock_refresh,
+            minute=EXPECTED_CLOCK_REFRESH_MINUTES,
+            second=0,
+        )
+        mock_native.assert_not_called()
+        assert coordinator._unsub_nordpool is unsub_nordpool
+        assert coordinator._unsub_clock_refresh is unsub_clock
+
+    def test_setup_refresh_tracking_subscribes_native_coordinator(self):
+        """Native setups should also subscribe to the native Nord Pool coordinator."""
+        coordinator = _make_coordinator_for_refresh_tracking(NORDPOOL_TYPE_NATIVE)
+
+        with (
+            patch(
+                "custom_components.power_saver.coordinator.async_track_state_change_event",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "custom_components.power_saver.coordinator.async_track_time_change",
+                return_value=MagicMock(),
+            ),
+            patch.object(coordinator, "_subscribe_native_coordinator") as mock_native,
+        ):
+            coordinator.async_setup_refresh_tracking()
+
+        mock_native.assert_called_once()
+
+    def test_clock_boundary_schedules_delayed_refresh(self):
+        """Quarter-hour fallback should wait briefly before refreshing."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        unsub_delay = MagicMock()
+
+        with patch(
+            "custom_components.power_saver.coordinator.async_call_later",
+            return_value=unsub_delay,
+        ) as mock_call_later:
+            coordinator._schedule_clock_refresh(datetime(2026, 2, 6, 14, 0))
+
+        mock_call_later.assert_called_once_with(
+            coordinator.hass,
+            EXPECTED_CLOCK_REFRESH_DELAY_SECONDS,
+            coordinator._on_clock_refresh_delay_elapsed,
+        )
+        assert coordinator._unsub_delayed_clock_refresh is unsub_delay
+
+    def test_clock_boundary_replaces_pending_delayed_refresh(self):
+        """A new boundary callback should cancel any pending delayed refresh."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        pending_unsub = MagicMock()
+        new_unsub = MagicMock()
+        coordinator._unsub_delayed_clock_refresh = pending_unsub
+
+        with patch(
+            "custom_components.power_saver.coordinator.async_call_later",
+            return_value=new_unsub,
+        ):
+            coordinator._schedule_clock_refresh(datetime(2026, 2, 6, 14, 0))
+
+        pending_unsub.assert_called_once()
+        assert coordinator._unsub_delayed_clock_refresh is new_unsub
+
+    def test_clock_boundary_skips_fallback_after_recent_nordpool_update(self):
+        """Fallback should not be scheduled when Nord Pool already refreshed."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        now = datetime(2026, 2, 6, 13, 0, 5, tzinfo=timezone.utc)
+        coordinator._last_nordpool_refresh_request = now - timedelta(seconds=3)
+
+        with (
+            patch(
+                "custom_components.power_saver.coordinator.dt_util.utcnow",
+                return_value=now,
+            ),
+            patch(
+                "custom_components.power_saver.coordinator.async_call_later",
+            ) as mock_call_later,
+        ):
+            coordinator._schedule_clock_refresh(datetime(2026, 2, 6, 14, 0))
+
+        mock_call_later.assert_not_called()
+        assert coordinator._unsub_delayed_clock_refresh is None
+
+    def test_nordpool_update_cancels_pending_fallback(self):
+        """Nord Pool updates should cancel the delayed fallback refresh."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        pending_unsub = MagicMock()
+        coordinator._unsub_delayed_clock_refresh = pending_unsub
+        now = datetime(2026, 2, 6, 13, 0, 0, tzinfo=timezone.utc)
+
+        with patch(
+            "custom_components.power_saver.coordinator.dt_util.utcnow",
+            return_value=now,
+        ):
+            coordinator._on_nordpool_update(MagicMock())
+
+        pending_unsub.assert_called_once()
+        assert coordinator._unsub_delayed_clock_refresh is None
+        assert coordinator._last_nordpool_refresh_request == now
+        coordinator.async_request_refresh.assert_called_once()
+        coordinator.hass.async_create_task.assert_called_once()
+
+    def test_native_update_cancels_pending_fallback(self):
+        """Native coordinator updates should cancel the delayed fallback refresh."""
+        coordinator = _make_coordinator_for_refresh_tracking(NORDPOOL_TYPE_NATIVE)
+        pending_unsub = MagicMock()
+        coordinator._unsub_delayed_clock_refresh = pending_unsub
+        now = datetime(2026, 2, 6, 13, 0, 0, tzinfo=timezone.utc)
+
+        with patch(
+            "custom_components.power_saver.coordinator.dt_util.utcnow",
+            return_value=now,
+        ):
+            coordinator._on_native_coordinator_update()
+
+        pending_unsub.assert_called_once()
+        assert coordinator._unsub_delayed_clock_refresh is None
+        assert coordinator._last_nordpool_refresh_request == now
+        coordinator.async_request_refresh.assert_called_once()
+        coordinator.hass.async_create_task.assert_called_once()
+
+    def test_delayed_clock_refresh_requests_refresh(self):
+        """Delayed fallback callback should request a coordinator refresh."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        coordinator._unsub_delayed_clock_refresh = MagicMock()
+
+        coordinator._on_clock_refresh_delay_elapsed(datetime(2026, 2, 6, 14, 0))
+
+        assert coordinator._unsub_delayed_clock_refresh is None
+        coordinator.async_request_refresh.assert_called_once()
+        coordinator.hass.async_create_task.assert_called_once()
+
+    async def test_shutdown_cancels_refresh_tracking_callbacks(self):
+        """Shutdown should clean up all refresh listeners and pending callbacks."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        coordinator._store = MagicMock()
+        coordinator._store.async_save = AsyncMock()
+        coordinator._last_on_time = None
+        coordinator._hours_override = None
+        coordinator._exclude_from_override = None
+        coordinator._exclude_until_override = None
+        coordinator._refresh_tracking_setup = True
+        coordinator._unsub_nordpool = MagicMock()
+        coordinator._unsub_native_coordinator = MagicMock()
+        coordinator._unsub_clock_refresh = MagicMock()
+        coordinator._unsub_delayed_clock_refresh = MagicMock()
+
+        with patch(
+            "custom_components.power_saver.coordinator.DataUpdateCoordinator.async_shutdown",
+            new=AsyncMock(),
+        ) as mock_super_shutdown:
+            await coordinator.async_shutdown()
+
+        assert coordinator._refresh_tracking_setup is False
+        assert coordinator._unsub_nordpool is None
+        assert coordinator._unsub_native_coordinator is None
+        assert coordinator._unsub_clock_refresh is None
+        assert coordinator._unsub_delayed_clock_refresh is None
+        mock_super_shutdown.assert_awaited_once()
 
 
 class TestLockedSchedule:
@@ -447,5 +688,3 @@ class TestShouldRecomputeSchedule:
         mock_coordinator._schedule_has_tomorrow = False
 
         assert mock_coordinator._should_recompute_schedule([], now) is True
-
-

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -22,6 +22,7 @@ build_schedule = scheduler.build_schedule
 NORDPOOL_TYPE_HACS = "hacs"
 NORDPOOL_TYPE_NATIVE = "native"
 EXPECTED_CLOCK_REFRESH_DELAY_SECONDS = 10
+EXPECTED_CLOCK_REFRESH_SUPPRESS_SECONDS = 20
 EXPECTED_CLOCK_REFRESH_MINUTES = (0, 15, 30, 45)
 
 
@@ -198,7 +199,7 @@ class TestRefreshTracking:
         """Fallback should not be scheduled when Nord Pool already refreshed."""
         coordinator = _make_coordinator_for_refresh_tracking()
         now = datetime(2026, 2, 6, 13, 0, 5, tzinfo=timezone.utc)
-        coordinator._last_nordpool_refresh_request = now - timedelta(seconds=3)
+        coordinator._last_nordpool_refresh_request = now - timedelta(seconds=14)
 
         with (
             patch(
@@ -213,6 +214,30 @@ class TestRefreshTracking:
 
         mock_call_later.assert_not_called()
         assert coordinator._unsub_delayed_clock_refresh is None
+
+    def test_clock_boundary_schedules_fallback_after_suppression_window(self):
+        """Fallback should run when the Nord Pool request is no longer recent."""
+        coordinator = _make_coordinator_for_refresh_tracking()
+        now = datetime(2026, 2, 6, 13, 0, 0, tzinfo=timezone.utc)
+        coordinator._last_nordpool_refresh_request = now - timedelta(
+            seconds=EXPECTED_CLOCK_REFRESH_SUPPRESS_SECONDS + 1
+        )
+        unsub_delay = MagicMock()
+
+        with (
+            patch(
+                "custom_components.power_saver.coordinator.dt_util.utcnow",
+                return_value=now,
+            ),
+            patch(
+                "custom_components.power_saver.coordinator.async_call_later",
+                return_value=unsub_delay,
+            ) as mock_call_later,
+        ):
+            coordinator._schedule_clock_refresh(datetime(2026, 2, 6, 14, 0))
+
+        mock_call_later.assert_called_once()
+        assert coordinator._unsub_delayed_clock_refresh is unsub_delay
 
     def test_nordpool_update_cancels_pending_fallback(self):
         """Nord Pool updates should cancel the delayed fallback refresh."""


### PR DESCRIPTION
Implemented event-driven and clock-aligned refresh tracking in PowerSaverCoordinator. Power Saver now refreshes as soon as Nord Pool refresh, with a fallback at 10 seconds after each full quarter (00:10, 15:10 etc).

Closes https://github.com/jyourstone/power_saver/issues/41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Power Saver refreshes now align with quarter-hour boundaries for more timely data updates.
  * Added a brief fallback delay to prevent unnecessary duplicate refreshes.
  * Recent native data updates now suppress redundant fallback polling.
  * Refresh scheduling and cleanup are handled reliably during startup and shutdown.

* **Tests**
  * Added coverage for boundary timing, duplicate-refresh prevention, native updates, delayed fallbacks, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->