### PR TITLE
feat: price threshold fields follow the Nord Pool sensor's currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 - **Minimum consecutive hours** — Prevents short on/off cycles by requiring a minimum run duration
 - **Excluded hours** — Block a time range from ever being activated (e.g., avoid grid fee peak hours)
 - **Multiple instances** — Add one per appliance (water heater, floor heating, pool pump, etc.)
+- **Currency-aware** — Price threshold fields follow your Nord Pool sensor's currency (SEK, NOK, DKK, EUR, ...)
 - **Always on / Always off** — Force all controlled entities ON or OFF via switches, bypassing the schedule
 - **Dynamic hours override** — Adjust scheduled hours at runtime via service calls (ideal for automations based on temperature, weather, etc.)
 - **Emergency mode** — Keeps appliances running if price data is unavailable

--- a/custom_components/power_saver/config_flow.py
+++ b/custom_components/power_saver/config_flow.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     from homeassistant.config_entries import OptionsFlowWithConfigEntry as OptionsFlowWithReload
     _LEGACY_OPTIONS_FLOW = True
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import (
     EntitySelector,
     EntitySelectorConfig,
@@ -75,7 +75,7 @@ from .nordpool_adapter import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def _price_unit(hass, entity_id):
+def _price_unit(hass: HomeAssistant, entity_id: str | None) -> str:
     """Price unit for form fields, from the chosen Nord Pool sensor's currency."""
     state = hass.states.get(entity_id) if entity_id else None
     if state is None:

--- a/custom_components/power_saver/config_flow.py
+++ b/custom_components/power_saver/config_flow.py
@@ -65,9 +65,22 @@ from .const import (
     STRATEGY_LOWEST_PRICE,
     STRATEGY_MINIMUM_RUNTIME,
 )
-from .nordpool_adapter import detect_nordpool_type, find_all_nordpool_sensors
+from .nordpool_adapter import (
+    DEFAULT_PRICE_UNIT,
+    derive_price_unit,
+    detect_nordpool_type,
+    find_all_nordpool_sensors,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _price_unit(hass, entity_id):
+    """Price unit for form fields, from the chosen Nord Pool sensor's currency."""
+    state = hass.states.get(entity_id) if entity_id else None
+    if state is None:
+        return DEFAULT_PRICE_UNIT
+    return derive_price_unit(state.attributes)
 
 
 def _optional_number(key: str, defaults: dict[str, Any]) -> vol.Optional:
@@ -331,6 +344,9 @@ class PowerSaverConfigFlow(ConfigFlow, domain=DOMAIN):
                 options=options,
             )
 
+        price_unit = _price_unit(
+            self.hass, self._user_input.get(CONF_NORDPOOL_SENSOR)
+        )
         schema = vol.Schema(
             {
                 vol.Required(
@@ -354,13 +370,13 @@ class PowerSaverConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_ALWAYS_CHEAP): NumberSelector(
                     NumberSelectorConfig(
                         min=-10, max=100, step=0.01, mode=NumberSelectorMode.BOX,
-                        unit_of_measurement="SEK/kWh",
+                        unit_of_measurement=price_unit,
                     )
                 ),
                 vol.Optional(CONF_ALWAYS_EXPENSIVE): NumberSelector(
                     NumberSelectorConfig(
                         min=0, max=100, step=0.01, mode=NumberSelectorMode.BOX,
-                        unit_of_measurement="SEK/kWh",
+                        unit_of_measurement=price_unit,
                     )
                 ),
                 vol.Optional(CONF_PRICE_SIMILARITY_PCT): NumberSelector(
@@ -570,6 +586,9 @@ class PowerSaverOptionsFlow(OptionsFlowWithReload):
             self._options.update(user_input)
             return self.async_create_entry(data=self._options)
 
+        price_unit = _price_unit(
+            self.hass, self.config_entry.data.get(CONF_NORDPOOL_SENSOR)
+        )
         schema = vol.Schema(
             {
                 vol.Required(
@@ -594,13 +613,13 @@ class PowerSaverOptionsFlow(OptionsFlowWithReload):
                 _optional_number(CONF_ALWAYS_CHEAP, defaults): NumberSelector(
                     NumberSelectorConfig(
                         min=-10, max=100, step=0.01, mode=NumberSelectorMode.BOX,
-                        unit_of_measurement="SEK/kWh",
+                        unit_of_measurement=price_unit,
                     )
                 ),
                 _optional_number(CONF_ALWAYS_EXPENSIVE, defaults): NumberSelector(
                     NumberSelectorConfig(
                         min=0, max=100, step=0.01, mode=NumberSelectorMode.BOX,
-                        unit_of_measurement="SEK/kWh",
+                        unit_of_measurement=price_unit,
                     )
                 ),
                 _optional_number(CONF_PRICE_SIMILARITY_PCT, defaults): NumberSelector(

--- a/custom_components/power_saver/nordpool_adapter.py
+++ b/custom_components/power_saver/nordpool_adapter.py
@@ -14,6 +14,25 @@ from .const import NORDPOOL_TYPE_HACS, NORDPOOL_TYPE_NATIVE
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_PRICE_UNIT = "SEK/kWh"
+
+
+def derive_price_unit(attributes: dict) -> str:
+    """Derive the price unit (e.g. "SEK/kWh") from a Nord Pool sensor's attributes.
+
+    Prefers the sensor's own unit_of_measurement when it is a per-kWh unit
+    (native and HACS Nord Pool both report e.g. "EUR/kWh"); falls back to
+    the HACS integration's currency attribute; defaults to SEK/kWh so
+    existing installs are unaffected when neither is present.
+    """
+    unit = attributes.get("unit_of_measurement")
+    if isinstance(unit, str) and unit.endswith("/kWh"):
+        return unit
+    currency = attributes.get("currency")
+    if isinstance(currency, str) and currency:
+        return f"{currency}/kWh"
+    return DEFAULT_PRICE_UNIT
+
 
 def detect_nordpool_type(hass: HomeAssistant, entity_id: str) -> str:
     """Detect whether an entity is a HACS Nord Pool or native HA Nord Pool sensor.

--- a/tests/test_nordpool_adapter.py
+++ b/tests/test_nordpool_adapter.py
@@ -14,8 +14,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.power_saver.const import NORDPOOL_TYPE_HACS, NORDPOOL_TYPE_NATIVE
 from custom_components.power_saver.nordpool_adapter import (
+    DEFAULT_PRICE_UNIT,
     _convert_native_response,
     _get_native_coordinator_prices,
+    derive_price_unit,
     find_all_nordpool_sensors,
 )
 
@@ -671,3 +673,23 @@ class TestGetNativeCoordinatorPrices:
         today_prices, tomorrow_prices = result
         assert len(today_prices) == 1
         assert tomorrow_prices == []
+
+
+class TestDerivePriceUnit:
+    """derive_price_unit(): form-field currency follows the Nord Pool sensor."""
+
+    def test_unit_of_measurement_wins(self):
+        assert derive_price_unit({"unit_of_measurement": "EUR/kWh"}) == "EUR/kWh"
+        assert derive_price_unit({"unit_of_measurement": "NOK/kWh"}) == "NOK/kWh"
+
+    def test_non_kwh_unit_falls_back_to_currency(self):
+        attrs = {"unit_of_measurement": "öre", "currency": "DKK"}
+        assert derive_price_unit(attrs) == "DKK/kWh"
+
+    def test_currency_attribute_alone(self):
+        assert derive_price_unit({"currency": "EUR"}) == "EUR/kWh"
+
+    def test_defaults_to_sek(self):
+        assert derive_price_unit({}) == DEFAULT_PRICE_UNIT
+        assert derive_price_unit({"currency": ""}) == DEFAULT_PRICE_UNIT
+        assert derive_price_unit({"unit_of_measurement": None}) == DEFAULT_PRICE_UNIT


### PR DESCRIPTION
## What
The always-cheap / always-expensive price threshold fields in the config and options flows now show the currency of the configured Nord Pool sensor instead of a hardcoded `SEK/kWh`.

## Why
Power Saver's scheduling math is currency-agnostic — the only SEK-specific thing was the form-field unit label. Users in NOK/DKK/EUR Nord Pool areas now see their own currency. Same change just shipped in Energy Manager.

## Changes
- `derive_price_unit()` in `nordpool_adapter.py`: sensor `unit_of_measurement` (when per-kWh) → HACS `currency` attribute → `SEK/kWh` fallback
- Both `common_options` steps build their `NumberSelector` units from the selected sensor (config flow: pending selection; options flow: entry data, which is where sensor changes are stored)
- Tests for the derivation (287 total passing), README feature bullet

Display only — no conversion anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEEYGbq4yvmrNr5XFjFx5Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Price threshold fields now display the currency and per-kWh unit used by the selected Nord Pool sensor.
  * Added documentation for currency-aware price thresholds.

* **Bug Fixes**
  * Added fallback handling to show a standard price unit when sensor currency or unit information is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->