### PR TITLE
fix: read native Nord Pool prices from pynordpool 0.4.0 cache

### DIFF
--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -525,6 +525,14 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
             else:
                 current_state = STATE_ACTIVE
 
+            # Emergency mode is the safety net that keeps the appliance running
+            # without prices, so it has to actually drive the entities — an
+            # appliance that was off when prices vanished used to stay off
+            # while this reported it as active.
+            if current_state != self._previous_state:
+                await self._control_entities(current_state)
+                self._previous_state = current_state
+
             emergency_schedule = []
             for i in range(96):  # 24 hours * 4 slots per hour
                 slot_time = now + timedelta(minutes=i * 15)

--- a/custom_components/power_saver/coordinator.py
+++ b/custom_components/power_saver/coordinator.py
@@ -499,6 +499,18 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
             )
             max_hours_off = 0
 
+        # A single failed price read is not an emergency. Nord Pool refreshes
+        # on the hour and can briefly return nothing; while the locked schedule
+        # still covers the current time it stays authoritative.
+        if not raw_today and self._locked_schedule:
+            if scheduler.find_current_slot(self._locked_schedule, now) is not None:
+                _LOGGER.warning(
+                    "No price data from Nord Pool sensor, reusing locked schedule"
+                )
+                return await self._build_data(
+                    self._locked_schedule, now, strategy, period_from, period_to, []
+                )
+
         # Emergency mode: no price data at all
         if not raw_today and not raw_tomorrow:
             _LOGGER.error(
@@ -573,6 +585,24 @@ class PowerSaverCoordinator(DataUpdateCoordinator[PowerSaverData]):
         else:
             schedule = self._locked_schedule
 
+        return await self._build_data(
+            schedule, now, strategy, period_from, period_to, raw_today
+        )
+
+    async def _build_data(
+        self,
+        schedule: list[dict],
+        now: datetime,
+        strategy: str,
+        period_from: str,
+        period_to: str,
+        raw_today: list[dict],
+    ) -> PowerSaverData:
+        """Derive the current state and sensor values from a schedule.
+
+        ``raw_today`` may be empty when prices are temporarily unavailable and
+        the locked schedule is being reused; min/max price are then omitted.
+        """
         # Find current slot
         current_slot = scheduler.find_current_slot(schedule, now)
         if current_slot:

--- a/custom_components/power_saver/nordpool_adapter.py
+++ b/custom_components/power_saver/nordpool_adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime, timedelta
 
+import aiohttp
+
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -222,6 +224,11 @@ def _get_native_coordinator_prices(
     yesterday, today, and tomorrow. Each entry has a requested_date (str)
     and entries (list of DeliveryPeriodEntry with start, end, entry attrs).
 
+    pynordpool changed the container type of DeliveryPeriodsData.entries in
+    0.4.0 (shipped with HA 2026.8) from list[DeliveryPeriodData] to
+    dict[date, DeliveryPeriodData]. Iterating the dict yields date keys, so
+    both shapes are normalized to the delivery periods themselves here.
+
     Returns (today_prices, tomorrow_prices) or None if unable to read.
     """
     coordinator = getattr(config_entry, "runtime_data", None)
@@ -235,6 +242,8 @@ def _get_native_coordinator_prices(
     entries = getattr(data, "entries", None)
     if not entries:
         return None
+
+    delivery_periods = entries.values() if isinstance(entries, dict) else entries
 
     # Get area(s) from the native config entry's data
     areas = config_entry.data.get("areas", [])
@@ -251,7 +260,7 @@ def _get_native_coordinator_prices(
     tomorrow_prices: list[dict] = []
 
     try:
-        for delivery_period in entries:
+        for delivery_period in delivery_periods:
             requested_date = getattr(delivery_period, "requested_date", None)
             period_entries = getattr(delivery_period, "entries", [])
 
@@ -304,7 +313,11 @@ async def _async_fetch_native_date(
             blocking=True,
             return_response=True,
         )
-    except (HomeAssistantError, KeyError, ValueError):
+    except (HomeAssistantError, aiohttp.ClientError, TimeoutError, KeyError, ValueError):
+        # pynordpool only wraps its own NordPool* errors, so transport-level
+        # failures (connection refused, DNS, TLS) surface as raw aiohttp
+        # errors through the service call. Uncaught, they escape the
+        # coordinator and mark every entity unavailable.
         _LOGGER.debug(
             "Failed to fetch native Nord Pool prices for %s (may not be available yet)",
             target_date,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -770,3 +770,91 @@ class TestTransientPriceLoss:
         data = await self._run(coord, now + timedelta(days=3))
 
         assert data.emergency_mode is True
+
+
+class TestEmergencyModeControlsEntities:
+    """Emergency mode must actually run the appliance, not just claim to.
+
+    It reported STATE_ACTIVE but returned before calling _control_entities, so
+    a device that was off when prices vanished stayed off while the sensor
+    showed it as active.
+    """
+
+    @pytest.fixture
+    def coord(self):
+        from custom_components.power_saver.coordinator import PowerSaverCoordinator
+
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "test_emergency"
+        entry.data = {
+            "nordpool_sensor": "sensor.nordpool",
+            "nordpool_type": "hacs",
+        }
+        entry.options = {"strategy": "lowest_price", "hours_per_period": 2.0}
+
+        with patch("custom_components.power_saver.coordinator.Store"):
+            coord = PowerSaverCoordinator(hass, entry)
+
+        coord._state_loaded = True
+        coord._store = AsyncMock()
+        coord._control_entities = AsyncMock()
+        return coord
+
+    async def _run(self, coord, now):
+        with patch(
+            "custom_components.power_saver.coordinator.async_get_prices",
+            AsyncMock(return_value=([], [])),
+        ), patch(
+            "custom_components.power_saver.coordinator.dt_util.now",
+            return_value=now,
+        ):
+            return await coord._async_update_data()
+
+    async def test_turns_on_device_that_was_off(self, coord, now):
+        """The case that silently failed: appliance off when prices vanish."""
+        coord._previous_state = "standby"
+
+        data = await self._run(coord, now)
+
+        assert data.emergency_mode is True
+        coord._control_entities.assert_awaited_once_with("active")
+        assert coord._previous_state == "active"
+
+    async def test_does_not_re_trigger_while_already_active(self, coord, now):
+        """Repeated emergency refreshes must not spam the service call."""
+        coord._previous_state = "active"
+
+        await self._run(coord, now)
+
+        coord._control_entities.assert_not_awaited()
+
+    async def test_force_off_still_wins(self, coord, now):
+        """Always off must keep the appliance off even during an outage."""
+        coord._force_off = True
+        coord._previous_state = "active"
+
+        data = await self._run(coord, now)
+
+        assert data.current_state == "forced_off"
+        coord._control_entities.assert_awaited_once_with("forced_off")
+
+    async def test_recovery_transition_uses_emergency_state(self, coord, now, today_prices):
+        """After emergency, _previous_state must reflect what was actually set."""
+        coord._previous_state = "standby"
+        await self._run(coord, now)
+        coord._control_entities.reset_mock()
+
+        # Prices return; schedule puts us in standby at `now`
+        with patch(
+            "custom_components.power_saver.coordinator.async_get_prices",
+            AsyncMock(return_value=(today_prices, [])),
+        ), patch(
+            "custom_components.power_saver.coordinator.dt_util.now",
+            return_value=now,
+        ):
+            data = await coord._async_update_data()
+
+        assert data.emergency_mode is False
+        if data.current_state != "active":
+            coord._control_entities.assert_awaited_once_with(data.current_state)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -713,3 +713,60 @@ class TestShouldRecomputeSchedule:
         mock_coordinator._schedule_has_tomorrow = False
 
         assert mock_coordinator._should_recompute_schedule([], now) is True
+
+
+class TestTransientPriceLoss:
+    """A failed price read must not discard a schedule that still applies.
+
+    Nord Pool refreshes on the hour and can briefly return nothing; that used
+    to trip emergency mode (a "problem" badge) every hour. See issue #45.
+    """
+
+    @pytest.fixture
+    def coord(self, now, today_prices):
+        from custom_components.power_saver.coordinator import PowerSaverCoordinator
+
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "test_transient"
+        entry.data = {
+            "nordpool_sensor": "sensor.nordpool",
+            "nordpool_type": "hacs",
+        }
+        entry.options = {"strategy": "lowest_price", "hours_per_period": 2.0}
+
+        with patch("custom_components.power_saver.coordinator.Store"):
+            coord = PowerSaverCoordinator(hass, entry)
+
+        coord._state_loaded = True
+        coord._locked_schedule = build_schedule(
+            raw_today=today_prices, raw_tomorrow=[], min_hours=2.0, now=now
+        )
+        coord._options_fingerprint = coord._compute_options_fingerprint()
+        coord._control_entities = AsyncMock()
+        return coord
+
+    async def _run(self, coord, now):
+        with patch(
+            "custom_components.power_saver.coordinator.async_get_prices",
+            AsyncMock(return_value=([], [])),
+        ), patch(
+            "custom_components.power_saver.coordinator.dt_util.now",
+            return_value=now,
+        ):
+            return await coord._async_update_data()
+
+    async def test_reuses_locked_schedule_instead_of_emergency(self, coord, now):
+        """Prices vanish while the locked schedule still covers now."""
+        data = await self._run(coord, now)
+
+        assert data.emergency_mode is False
+        assert data.schedule == coord._locked_schedule
+        assert data.min_price is None
+        assert data.max_price is None
+
+    async def test_emergency_when_schedule_no_longer_covers_now(self, coord, now):
+        """Past the schedule's horizon there is nothing left to fall back on."""
+        data = await self._run(coord, now + timedelta(days=3))
+
+        assert data.emergency_mode is True

--- a/tests/test_nordpool_adapter.py
+++ b/tests/test_nordpool_adapter.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.power_saver.const import NORDPOOL_TYPE_HACS, NORDPOOL_TYPE_NATIVE
 from custom_components.power_saver.nordpool_adapter import (
     DEFAULT_PRICE_UNIT,
+    _async_fetch_native_date,
     _convert_native_response,
     _get_native_coordinator_prices,
     derive_price_unit,
@@ -42,9 +45,16 @@ class MockDeliveryPeriodData:
 
 @dataclass
 class MockDeliveryPeriodsData:
-    """Mock for pynordpool DeliveryPeriodsData."""
+    """Mock for pynordpool DeliveryPeriodsData.
 
-    entries: list[MockDeliveryPeriodData] = field(default_factory=list)
+    pynordpool < 0.3 typed ``entries`` as ``list[DeliveryPeriodData]``;
+    0.4.0 (HA 2026.8) changed it to ``dict[date, DeliveryPeriodData]``.
+    Both shapes are exercised by the tests below.
+    """
+
+    entries: list[MockDeliveryPeriodData] | dict[date, MockDeliveryPeriodData] = field(
+        default_factory=list
+    )
 
 
 class TestConvertNativeResponse:
@@ -412,8 +422,13 @@ def _make_mock_config_entry(
     today_entries: list[MockDeliveryPeriodEntry],
     tomorrow_str: str | None = None,
     tomorrow_entries: list[MockDeliveryPeriodEntry] | None = None,
+    as_dict: bool = False,
 ):
-    """Create a mock config entry with native coordinator data."""
+    """Create a mock config entry with native coordinator data.
+
+    ``as_dict`` selects the pynordpool 0.4.0 shape, where ``entries`` is a
+    dict keyed by delivery date instead of a list.
+    """
     periods = [MockDeliveryPeriodData(requested_date=today_str, entries=today_entries)]
     if tomorrow_str is not None:
         periods.append(
@@ -424,7 +439,14 @@ def _make_mock_config_entry(
         )
 
     coordinator = MagicMock()
-    coordinator.data = MockDeliveryPeriodsData(entries=periods)
+    if as_dict:
+        coordinator.data = MockDeliveryPeriodsData(
+            entries={
+                date.fromisoformat(period.requested_date): period for period in periods
+            }
+        )
+    else:
+        coordinator.data = MockDeliveryPeriodsData(entries=periods)
 
     entry = MagicMock()
     entry.data = {"areas": areas}
@@ -673,6 +695,123 @@ class TestGetNativeCoordinatorPrices:
         today_prices, tomorrow_prices = result
         assert len(today_prices) == 1
         assert tomorrow_prices == []
+
+
+@patch(
+    "custom_components.power_saver.nordpool_adapter.dt_util.now",
+    return_value=MOCK_NOW,
+)
+class TestGetNativeCoordinatorPricesDictEntries:
+    """pynordpool 0.4.0 (HA 2026.8) keys ``entries`` by date instead of listing it.
+
+    Iterating that dict yields ``date`` keys, so reading ``requested_date`` off
+    each item silently produced nothing and every refresh fell back to live API
+    service calls. See issue #45.
+    """
+
+    def test_reads_today_and_tomorrow_from_dict(self, _mock_now):
+        """Dict-shaped entries must resolve today and tomorrow prices."""
+        today_entries = [
+            MockDeliveryPeriodEntry(
+                start=datetime(2026, 3, 12, 0, 0, tzinfo=CET),
+                end=datetime(2026, 3, 12, 1, 0, tzinfo=CET),
+                entry={"SE4": 500.0},
+            ),
+            MockDeliveryPeriodEntry(
+                start=datetime(2026, 3, 12, 1, 0, tzinfo=CET),
+                end=datetime(2026, 3, 12, 2, 0, tzinfo=CET),
+                entry={"SE4": 300.0},
+            ),
+        ]
+        tomorrow_entries = [
+            MockDeliveryPeriodEntry(
+                start=datetime(2026, 3, 13, 0, 0, tzinfo=CET),
+                end=datetime(2026, 3, 13, 1, 0, tzinfo=CET),
+                entry={"SE4": 200.0},
+            ),
+        ]
+
+        config_entry = _make_mock_config_entry(
+            areas=["SE4"],
+            today_str="2026-03-12",
+            today_entries=today_entries,
+            tomorrow_str="2026-03-13",
+            tomorrow_entries=tomorrow_entries,
+            as_dict=True,
+        )
+
+        result = _get_native_coordinator_prices(config_entry)
+
+        assert result is not None
+        today_prices, tomorrow_prices = result
+        assert len(today_prices) == 2
+        assert today_prices[0]["value"] == pytest.approx(0.5)
+        assert today_prices[1]["value"] == pytest.approx(0.3)
+        assert len(tomorrow_prices) == 1
+        assert tomorrow_prices[0]["value"] == pytest.approx(0.2)
+
+    def test_today_only_from_dict(self, _mock_now):
+        """Missing tomorrow key yields an empty tomorrow list, not None."""
+        today_entries = [
+            MockDeliveryPeriodEntry(
+                start=datetime(2026, 3, 12, 0, 0, tzinfo=CET),
+                end=datetime(2026, 3, 12, 1, 0, tzinfo=CET),
+                entry={"SE4": 400.0},
+            ),
+        ]
+
+        config_entry = _make_mock_config_entry(
+            areas=["SE4"],
+            today_str="2026-03-12",
+            today_entries=today_entries,
+            as_dict=True,
+        )
+
+        result = _get_native_coordinator_prices(config_entry)
+
+        assert result is not None
+        today_prices, tomorrow_prices = result
+        assert len(today_prices) == 1
+        assert tomorrow_prices == []
+
+    def test_dict_without_today_returns_none(self, _mock_now):
+        """Only stale days cached — caller must fall back to service calls."""
+        config_entry = _make_mock_config_entry(
+            areas=["SE4"],
+            today_str="2026-03-10",
+            today_entries=[
+                MockDeliveryPeriodEntry(
+                    start=datetime(2026, 3, 10, 0, 0, tzinfo=CET),
+                    end=datetime(2026, 3, 10, 1, 0, tzinfo=CET),
+                    entry={"SE4": 100.0},
+                ),
+            ],
+            as_dict=True,
+        )
+
+        assert _get_native_coordinator_prices(config_entry) is None
+
+
+class TestFetchNativeDateErrors:
+    """Transport failures must degrade to no prices, not escape the coordinator."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            aiohttp.ClientConnectorError(MagicMock(), OSError("Network unreachable")),
+            aiohttp.ClientError("boom"),
+            TimeoutError(),
+            HomeAssistantError("entry not loaded"),
+        ],
+    )
+    async def test_transport_errors_return_empty(self, error):
+        """pynordpool lets raw aiohttp errors through the service call."""
+        hass = MagicMock()
+        hass.services.async_call = AsyncMock(side_effect=error)
+
+        result = await _async_fetch_native_date(hass, "entry_id", date(2026, 3, 12))
+
+        assert result == []
 
 
 class TestDerivePriceUnit:


### PR DESCRIPTION
## What

Fixes the hourly "problem" badge and unavailable entities reported on native Nord Pool installs.

Closes #45

## Why

`pynordpool` 0.4.0 (shipped with HA 2026.8) changed `DeliveryPeriodsData.entries` from `list[DeliveryPeriodData]` to `dict[date, DeliveryPeriodData]`.

`_get_native_coordinator_prices` iterated it directly, which on a dict yields `date` keys:

```python
for delivery_period in entries:                                    # date objects
    requested_date = getattr(delivery_period, "requested_date", None)   # None
```

The `getattr` defaults swallowed the mismatch, so no exception was raised — the function just returned `None` on every refresh. Every coordinator update then fell back to live `nordpool.get_prices_for_date` service calls.

That fallback fires on every refresh, per config entry. At the top of each hour the native coordinator makes its own three API calls and notifies listeners, which triggers ours on top — a burst against the Nord Pool API once an hour. The resulting connection failures surfaced as emergency mode (`binary_sensor` device class `PROBLEM`) and unavailable entities, clearing at the next quarter-hour refresh. HACS installs never hit this code path, which is why switching to HACS "fixed" it for the reporter.

## Changes

- **`nordpool_adapter.py`** — normalize both container shapes (`entries.values()` when dict) so installs on HA 2024.11 through 2026.8+ all work
- **`nordpool_adapter.py`** — catch `aiohttp.ClientError` and `TimeoutError` in `_async_fetch_native_date`. `pynordpool._get` only catches its own `NordPool*` exceptions and HA's `nordpool` service doesn't wrap transport errors either, so connection/DNS/TLS failures escaped the coordinator and marked every entity unavailable
- **`coordinator.py`** — reuse the locked schedule when a price read fails but the schedule still covers the current time, instead of tripping emergency mode. A single bad read is no longer an emergency
- **`coordinator.py`** — extract the state-derivation tail into `_build_data()`, shared by the normal and fallback paths
- **`coordinator.py`** — emergency mode now actually drives the controlled entities. It reported `STATE_ACTIVE` but returned before calling `_control_entities`, so an appliance that was off when prices vanished stayed off while the sensor showed it as active — the opposite of the safety net the README describes. It also left `_previous_state` stale, breaking the first transition after emergency ended. Routed through the same change-guarded control logic as the normal path, so it stays idempotent and Always off still wins during an outage
- **tests** — dict-shaped coordinator data, transport-error handling, transient price-loss, and emergency-mode entity control

## Verification

All new tests confirmed failing against the original source before the fix, including emergency mode firing on the transient-loss case and `_control_entities` never being awaited on the emergency path. Full suite: 300 passed.

Verified live on HA 2026.8.2 with native Nord Pool (pynordpool 0.4.0):

| | before | after |
|---|---|---|
| `Read prices from native coordinator cache` | 0 | 4 (`today=96, tomorrow=96`) |
| `Falling back to service calls` | 4 | 0 |
| power_saver ERRORs | — | 0 |

The emergency-mode change is covered by tests only — reproducing it live needs a total price outage, which wasn't staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnWfo4Tf5yHpaX6sNZ5Ye5