### PR TITLE
fix: bucket Nord Pool prices by local day, not CET delivery day

### DIFF
--- a/custom_components/power_saver/nordpool_adapter.py
+++ b/custom_components/power_saver/nordpool_adapter.py
@@ -36,6 +36,44 @@ def derive_price_unit(attributes: dict) -> str:
     return DEFAULT_PRICE_UNIT
 
 
+def split_by_local_day(
+    slots: list[dict], now: datetime
+) -> tuple[list[dict], list[dict]]:
+    """Bucket price slots into Home Assistant's local today and tomorrow.
+
+    Nord Pool delivery days are defined in CET, and the API labels each batch
+    with deliveryDateCET. Sorting batches by that label assigns whole CET days
+    to "today", which silently shifts the scheduling day for anyone outside
+    CET — EET (Finland, Baltics) runs an hour ahead, the UK an hour behind.
+
+    Slots are therefore assigned by their own start timestamp converted to
+    local time. Slots outside today and tomorrow are dropped, so callers that
+    supply only the CET days overlapping the local ones may come up short at
+    one edge; that is preferable to mislabelling a whole day.
+    """
+    today = now.date()
+    tomorrow = today + timedelta(days=1)
+
+    buckets: dict[date, list[tuple[datetime, dict]]] = {today: [], tomorrow: []}
+    for slot in slots:
+        start = slot.get("start")
+        try:
+            start_dt = (
+                start if isinstance(start, datetime) else datetime.fromisoformat(start)
+            ).astimezone(now.tzinfo)
+        except (TypeError, ValueError):
+            continue
+
+        bucket = buckets.get(start_dt.date())
+        if bucket is not None:
+            bucket.append((start_dt, slot))
+
+    return (
+        [slot for _dt, slot in sorted(buckets[today], key=lambda p: p[0])],
+        [slot for _dt, slot in sorted(buckets[tomorrow], key=lambda p: p[0])],
+    )
+
+
 def detect_nordpool_type(hass: HomeAssistant, entity_id: str) -> str:
     """Detect whether an entity is a HACS Nord Pool or native HA Nord Pool sensor.
 
@@ -204,15 +242,18 @@ async def _async_get_native_prices(
             )
             return raw_today, raw_tomorrow
 
-    # Fallback: individual service calls
+    # Fallback: individual service calls. The service takes a CET delivery
+    # date, so the two days fetched here are re-bucketed by local day rather
+    # than assumed to be the local today/tomorrow.
     _LOGGER.debug("Falling back to service calls for native Nord Pool prices")
-    today = dt_util.now().date()
+    now = dt_util.now()
+    today = now.date()
     tomorrow = today + timedelta(days=1)
 
-    raw_today = await _async_fetch_native_date(hass, config_entry_id, today)
-    raw_tomorrow = await _async_fetch_native_date(hass, config_entry_id, tomorrow)
+    fetched = await _async_fetch_native_date(hass, config_entry_id, today)
+    fetched += await _async_fetch_native_date(hass, config_entry_id, tomorrow)
 
-    return raw_today, raw_tomorrow
+    return split_by_local_day(fetched, now)
 
 
 def _get_native_coordinator_prices(
@@ -252,33 +293,18 @@ def _get_native_coordinator_prices(
         return None
     area = areas[0]
 
-    now = dt_util.now()
-    today_str = now.strftime("%Y-%m-%d")
-    tomorrow_str = (now + timedelta(days=1)).strftime("%Y-%m-%d")
-
-    today_prices: list[dict] = []
-    tomorrow_prices: list[dict] = []
+    slots: list[dict] = []
 
     try:
         for delivery_period in delivery_periods:
-            requested_date = getattr(delivery_period, "requested_date", None)
-            period_entries = getattr(delivery_period, "entries", [])
-
-            if requested_date == today_str:
-                target = today_prices
-            elif requested_date == tomorrow_str:
-                target = tomorrow_prices
-            else:
-                continue
-
-            for entry in period_entries:
-                start = entry.start
-                end = entry.end
+            for entry in getattr(delivery_period, "entries", []):
                 price_mwh = entry.entry.get(area)
                 if price_mwh is None:
                     continue
 
-                target.append({
+                start = entry.start
+                end = entry.end
+                slots.append({
                     "start": (
                         start if isinstance(start, str) else start.isoformat()
                     ),
@@ -291,6 +317,8 @@ def _get_native_coordinator_prices(
             exc_info=True,
         )
         return None
+
+    today_prices, tomorrow_prices = split_by_local_day(slots, dt_util.now())
 
     if not today_prices:
         return None

--- a/tests/test_nordpool_adapter.py
+++ b/tests/test_nordpool_adapter.py
@@ -792,6 +792,90 @@ class TestGetNativeCoordinatorPricesDictEntries:
         assert _get_native_coordinator_prices(config_entry) is None
 
 
+EET = timezone(timedelta(hours=3))  # Finland in summer, one hour ahead of CEST
+
+
+class TestLocalDayBucketing:
+    """"Today" must mean the user's local day, not Nord Pool's CET delivery day.
+
+    Nord Pool labels each price batch with deliveryDateCET. Matching that label
+    against Home Assistant's local date silently shifts the scheduling day for
+    anyone outside CET — EET (Finland, Baltics) runs an hour ahead, the UK an
+    hour behind.
+    """
+
+    def _cet_day(self, day: int, hours: int = 24) -> list[MockDeliveryPeriodEntry]:
+        """One CET delivery day of hourly slots, priced by hour for identification."""
+        return [
+            MockDeliveryPeriodEntry(
+                start=datetime(2026, 3, day, h, 0, tzinfo=CET),
+                end=datetime(2026, 3, day, h, 0, tzinfo=CET) + timedelta(hours=1),
+                entry={"SE4": float(h)},
+            )
+            for h in range(hours)
+        ]
+
+    def test_eet_user_gets_their_own_local_day(self):
+        """At 14:00 Finnish time, "today" is the Finnish calendar day."""
+        # Cache holds three CET delivery days, as the native coordinator does
+        periods = [
+            MockDeliveryPeriodData(requested_date="2026-03-11", entries=self._cet_day(11)),
+            MockDeliveryPeriodData(requested_date="2026-03-12", entries=self._cet_day(12)),
+            MockDeliveryPeriodData(requested_date="2026-03-13", entries=self._cet_day(13)),
+        ]
+        coordinator = MagicMock()
+        coordinator.data = MockDeliveryPeriodsData(entries=periods)
+        config_entry = MagicMock()
+        config_entry.data = {"areas": ["SE4"]}
+        config_entry.runtime_data = coordinator
+
+        now = datetime(2026, 3, 12, 14, 0, tzinfo=EET)
+        with patch(
+            "custom_components.power_saver.nordpool_adapter.dt_util.now",
+            return_value=now,
+        ):
+            result = _get_native_coordinator_prices(config_entry)
+
+        assert result is not None
+        today_prices, _tomorrow_prices = result
+
+        # Every slot returned as "today" must fall on the user's local 12 March
+        local_dates = {
+            datetime.fromisoformat(s["start"]).astimezone(EET).date()
+            for s in today_prices
+        }
+        assert local_dates == {date(2026, 3, 12)}
+
+        # A full local day, starting at local midnight
+        assert len(today_prices) == 24
+        first = datetime.fromisoformat(today_prices[0]["start"]).astimezone(EET)
+        assert (first.hour, first.minute) == (0, 0)
+
+    def test_cet_user_unaffected(self):
+        """The existing CET behaviour must not change."""
+        periods = [
+            MockDeliveryPeriodData(requested_date="2026-03-12", entries=self._cet_day(12)),
+            MockDeliveryPeriodData(requested_date="2026-03-13", entries=self._cet_day(13)),
+        ]
+        coordinator = MagicMock()
+        coordinator.data = MockDeliveryPeriodsData(entries=periods)
+        config_entry = MagicMock()
+        config_entry.data = {"areas": ["SE4"]}
+        config_entry.runtime_data = coordinator
+
+        now = datetime(2026, 3, 12, 14, 0, tzinfo=CET)
+        with patch(
+            "custom_components.power_saver.nordpool_adapter.dt_util.now",
+            return_value=now,
+        ):
+            result = _get_native_coordinator_prices(config_entry)
+
+        assert result is not None
+        today_prices, tomorrow_prices = result
+        assert len(today_prices) == 24
+        assert len(tomorrow_prices) == 24
+
+
 class TestFetchNativeDateErrors:
     """Transport failures must degrade to no prices, not escape the coordinator."""
 


### PR DESCRIPTION
## What

Makes "today" mean the user's local day rather than Nord Pool's CET delivery day.

Stacked on #46 — targets that branch, since it edits the same function. Merge #46 first, or say the word and I'll fold it in.

## Why

Nord Pool defines delivery days in CET and labels each batch with `deliveryDateCET`. Both native paths treated that as the local day:

- **cache read** — matched `requested_date` (a CET date string) against `dt_util.now()` (HA local)
- **service-call fallback** — passed `dt_util.now().date()` as the CET delivery date

For CET/CEST installs these agree, so nothing changes. For anyone else they don't. EET (Finland, Baltics) runs an hour ahead of CET, the UK an hour behind — so the batch labelled `2026-03-12` covers local 01:00 on the 12th through 01:00 on the 13th. "Today" was shifted by an hour.

This matters because in full-day mode the bucket **is** the scheduling period — `build_lowest_price_schedule` picks the N cheapest hours out of `raw_today` and separately out of `raw_tomorrow`. So the daily quota was being chosen over the wrong 24 hours.

Worse, the same code path then used a *different* definition of day for the consecutive-hours constraint:

```python
slot_date = datetime.fromisoformat(slot["time"]).date()   # local date
```

Quota picked per CET day, consecutive-block enforcement grouped per local day. Identical for CET users; divergent for everyone else, which can slice a block spanning local midnight and deactivate slots through the consolidation path.

Found by reading the code, not from a bug report — no known user impact yet.

## Changes

- **`nordpool_adapter.py`** — new `split_by_local_day()`, which assigns each slot by its own `start` timestamp converted to local time and returns sorted today/tomorrow buckets
- **`nordpool_adapter.py`** — `_get_native_coordinator_prices()` now collects slots from every cached delivery period and buckets them locally, instead of selecting whole periods by label
- **`nordpool_adapter.py`** — the service-call fallback re-buckets its two fetched days the same way
- **tests** — EET user gets a full local day starting at local midnight; CET behaviour verified unchanged

## Trade-off

`split_by_local_day()` drops slots outside today and tomorrow. On the fallback path a non-CET install can therefore come up an hour short at one edge, because the two CET days fetched don't fully cover the two local ones. Closing that would need a third API call on the path this PR series is already trying to avoid. Short-but-correctly-labelled beats a shifted day: the scheduler already copes with partial `raw_tomorrow`, but it cannot detect a shift.

The cache path is unaffected — the native coordinator caches yesterday/today/tomorrow, so local today is always fully covered.

## Verification

New EET test confirmed failing before the fix (`today` wrongly contained local 13 March slots); CET test passed throughout, confirming no behaviour change for existing users. Full suite: 302 passed.

Re-verified live on HA 2026.8.2 with native Nord Pool: `Read prices from native coordinator cache: today=96, tomorrow=96` ×12, zero service-call fallbacks, zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TnWfo4Tf5yHpaX6sNZ5Ye5